### PR TITLE
README.md: Change the example's arch to amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ image:
   variant: default # optional
   description: Ubuntu Artful # optional
   expiry: 30d # optional: defaults to 30d
-  arch: x86_64 # optional: defaults to local architecture
+  arch: amd64 # optional: defaults to local architecture
 
 source:
   downloader: ubuntu-http


### PR DESCRIPTION
When trying to download an ubuntu image [1], it does not feature any
image with arch x86_64, instead amd64 is used. So fix the README example
by setting the image's arch to amd64.

[1] http://cdimage.ubuntu.com/ubuntu-base/releases/artful/release/

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>