### PR TITLE
shared: Set default variant

### DIFF
--- a/shared/definition.go
+++ b/shared/definition.go
@@ -105,6 +105,11 @@ func SetDefinitionDefaults(def *Definition) {
 		def.Image.Expiry = "30d"
 	}
 
+	// Set default variant
+	if def.Image.Variant == "" {
+		def.Image.Variant = "default"
+	}
+
 	if def.Source.Keyserver == "" {
 		def.Source.Keyserver = "hkps.pool.sks-keyservers.net"
 	}


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>