### PR TITLE
Use yaml tags in pongo2 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ source:
   keyserver: pgp.mit.edu # optional
 
   apt_source:: |-
-    deb {{ source.URL }} {{ image.Release }} main restricted universe multiverse
-    deb {{ source.URL }} {{ image.Release }}-updates main restricted universe multiverse
-    deb http://security.ubuntu.com/ubuntu {{ image.Release }}-security main restricted universe multiverse
+    deb {{ source.url }} {{ image.release }} main restricted universe multiverse
+    deb {{ source.url }} {{ image.release }}-updates main restricted universe multiverse
+    deb http://security.ubuntu.com/ubuntu {{ image.release }}-security main restricted universe multiverse
 
 targets:
   lxc:
     create-message: |-
-        You just created an {{ image.Description }} container.
+        You just created an {{ image.description }} container.
 
         To enable SSH, run: apt install openssh-server
         No default root or user password are set by LXC.

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -46,8 +46,7 @@ func (c *cmdLXC) commandPack() *cobra.Command {
 
 func (c *cmdLXC) run(cmd *cobra.Command, args []string) error {
 	img := image.NewLXCImage(c.global.sourceDir, c.global.targetDir,
-		c.global.flagCacheDir, c.global.definition.Image,
-		c.global.definition.Targets.LXC)
+		c.global.flagCacheDir, *c.global.definition)
 
 	for _, file := range c.global.definition.Files {
 		generator := generators.Get(file.Generator)

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -65,7 +65,7 @@ func (c *cmdLXD) commandPack() *cobra.Command {
 
 func (c *cmdLXD) run(cmd *cobra.Command, args []string) error {
 	img := image.NewLXDImage(c.global.sourceDir, c.global.targetDir,
-		c.global.flagCacheDir, c.global.definition.Image)
+		c.global.flagCacheDir, *c.global.definition)
 
 	for _, file := range c.global.definition.Files {
 		if len(file.Releases) > 0 && !lxd.StringInSlice(c.global.definition.Image.Release,

--- a/generators/hostname_test.go
+++ b/generators/hostname_test.go
@@ -21,12 +21,14 @@ func TestHostnameGeneratorRunLXC(t *testing.T) {
 		t.Fatal("Expected hostname generator, got nil")
 	}
 
-	definition := shared.DefinitionImage{
-		Distribution: "ubuntu",
-		Release:      "artful",
+	definition := shared.Definition{
+		Image: shared.DefinitionImage{
+			Distribution: "ubuntu",
+			Release:      "artful",
+		},
 	}
 
-	image := image.NewLXCImage(cacheDir, "", cacheDir, definition, shared.DefinitionTargetLXC{})
+	image := image.NewLXCImage(cacheDir, "", cacheDir, definition)
 
 	err := os.MkdirAll(filepath.Join(cacheDir, "rootfs", "etc"), 0755)
 	if err != nil {
@@ -64,9 +66,11 @@ func TestHostnameGeneratorRunLXD(t *testing.T) {
 		t.Fatal("Expected hostname generator, got nil")
 	}
 
-	definition := shared.DefinitionImage{
-		Distribution: "ubuntu",
-		Release:      "artful",
+	definition := shared.Definition{
+		Image: shared.DefinitionImage{
+			Distribution: "ubuntu",
+			Release:      "artful",
+		},
 	}
 
 	image := image.NewLXDImage(cacheDir, "", cacheDir, definition)

--- a/generators/hosts_test.go
+++ b/generators/hosts_test.go
@@ -21,12 +21,14 @@ func TestHostsGeneratorRunLXC(t *testing.T) {
 		t.Fatal("Expected hosts generator, got nil")
 	}
 
-	definition := shared.DefinitionImage{
-		Distribution: "ubuntu",
-		Release:      "artful",
+	definition := shared.Definition{
+		Image: shared.DefinitionImage{
+			Distribution: "ubuntu",
+			Release:      "artful",
+		},
 	}
 
-	image := image.NewLXCImage(cacheDir, "", cacheDir, definition, shared.DefinitionTargetLXC{})
+	image := image.NewLXCImage(cacheDir, "", cacheDir, definition)
 
 	err := os.MkdirAll(filepath.Join(cacheDir, "rootfs", "etc"), 0755)
 	if err != nil {
@@ -68,9 +70,11 @@ func TestHostsGeneratorRunLXD(t *testing.T) {
 		t.Fatal("Expected hosts generator, got nil")
 	}
 
-	definition := shared.DefinitionImage{
-		Distribution: "ubuntu",
-		Release:      "artful",
+	definition := shared.Definition{
+		Image: shared.DefinitionImage{
+			Distribution: "ubuntu",
+			Release:      "artful",
+		},
 	}
 
 	image := image.NewLXDImage(cacheDir, "", cacheDir, definition)

--- a/image/lxc_test.go
+++ b/image/lxc_test.go
@@ -14,64 +14,67 @@ import (
 	"github.com/lxc/distrobuilder/shared"
 )
 
-var lxcImageDef = shared.DefinitionImage{
-	Description:  "{{ image. Distribution|capfirst }} {{ image.Release }}",
-	Distribution: "ubuntu",
-	Release:      "17.10",
-	Architecture: "amd64",
-	Expiry:       "30d",
-	Name:         "{{ image.Distribution|lower }}-{{ image.Release }}-{{ image.Architecture }}-{{ image.Serial }}",
-}
-
-var lxcTarget = shared.DefinitionTargetLXC{
-	CreateMessage: "Welcome to {{ image.Distribution|capfirst}} {{ image.Release }}",
-	Config: []shared.DefinitionTargetLXCConfig{
-		{
-			Type:    "all",
-			Before:  5,
-			Content: "all_before_5",
-		},
-		{
-			Type:    "user",
-			Before:  5,
-			Content: "user_before_5",
-		},
-		{
-			Type:    "all",
-			After:   4,
-			Content: "all_after_4",
-		},
-		{
-			Type:    "user",
-			After:   4,
-			Content: "user_after_4",
-		},
-		{
-			Type:    "all",
-			Content: "all",
-		},
-		{
-			Type:    "system",
-			Before:  2,
-			Content: "system_before_2",
-		},
-		{
-			Type:    "system",
-			Before:  2,
-			After:   4,
-			Content: "system_before_2_after_4",
-		},
-		{
-			Type:    "user",
-			Before:  3,
-			After:   3,
-			Content: "user_before_3_after_3",
-		},
-		{
-			Type:    "system",
-			Before:  4,
-			After:   2,
-			Content: "system_before_4_after_2",
+var lxcDef = shared.Definition{
+	Image: shared.DefinitionImage{
+		Description:  "{{ image. Distribution|capfirst }} {{ image.Release }}",
+		Distribution: "ubuntu",
+		Release:      "17.10",
+		Architecture: "amd64",
+		Expiry:       "30d",
+		Name:         "{{ image.Distribution|lower }}-{{ image.Release }}-{{ image.Architecture }}-{{ image.Serial }}",
+	},
+	Targets: shared.DefinitionTarget{
+		LXC: shared.DefinitionTargetLXC{
+			CreateMessage: "Welcome to {{ image.Distribution|capfirst}} {{ image.Release }}",
+			Config: []shared.DefinitionTargetLXCConfig{
+				{
+					Type:    "all",
+					Before:  5,
+					Content: "all_before_5",
+				},
+				{
+					Type:    "user",
+					Before:  5,
+					Content: "user_before_5",
+				},
+				{
+					Type:    "all",
+					After:   4,
+					Content: "all_after_4",
+				},
+				{
+					Type:    "user",
+					After:   4,
+					Content: "user_after_4",
+				},
+				{
+					Type:    "all",
+					Content: "all",
+				},
+				{
+					Type:    "system",
+					Before:  2,
+					Content: "system_before_2",
+				},
+				{
+					Type:    "system",
+					Before:  2,
+					After:   4,
+					Content: "system_before_2_after_4",
+				},
+				{
+					Type:    "user",
+					Before:  3,
+					After:   3,
+					Content: "user_before_3_after_3",
+				},
+				{
+					Type:    "system",
+					Before:  4,
+					After:   2,
+					Content: "system_before_4_after_2",
+				},
+			},
 		},
 	},
 }
@@ -82,7 +85,7 @@ func lxcCacheDir() string {
 }
 
 func setupLXC() *LXCImage {
-	return NewLXCImage(lxcCacheDir(), "", lxcCacheDir(), lxcImageDef, lxcTarget)
+	return NewLXCImage(lxcCacheDir(), "", lxcCacheDir(), lxcDef)
 }
 
 func teardownLXC() {
@@ -90,7 +93,7 @@ func teardownLXC() {
 }
 
 func TestNewLXCImage(t *testing.T) {
-	image := NewLXCImage(lxcCacheDir(), "", lxcCacheDir(), lxcImageDef, lxcTarget)
+	image := NewLXCImage(lxcCacheDir(), "", lxcCacheDir(), lxcDef)
 	defer teardownLXC()
 
 	if image.cacheDir != lxcCacheDir() {
@@ -98,12 +101,8 @@ func TestNewLXCImage(t *testing.T) {
 			image.cacheDir)
 	}
 
-	if !reflect.DeepEqual(image.definition, lxcImageDef) {
+	if !reflect.DeepEqual(image.definition, lxcDef) {
 		t.Fatalf("lxcImageDef and image.definition are not equal")
-	}
-
-	if !reflect.DeepEqual(image.target, lxcTarget) {
-		t.Fatalf("lxcTarget and image.target are not equal")
 	}
 }
 
@@ -192,7 +191,7 @@ func TestLXCCreateMetadataBasic(t *testing.T) {
 			true,
 			"Error writing 'config': .+",
 			func(l LXCImage) *LXCImage {
-				l.target.Config = []shared.DefinitionTargetLXCConfig{
+				l.definition.Targets.LXC.Config = []shared.DefinitionTargetLXCConfig{
 					{
 						Type:    "all",
 						After:   4,
@@ -207,7 +206,7 @@ func TestLXCCreateMetadataBasic(t *testing.T) {
 			true,
 			"Error writing 'create-message': .+",
 			func(l LXCImage) *LXCImage {
-				l.target.CreateMessage = "{{ invalid }"
+				l.definition.Targets.LXC.CreateMessage = "{{ invalid }"
 				return &l
 			},
 		},

--- a/image/lxd_test.go
+++ b/image/lxd_test.go
@@ -14,14 +14,16 @@ import (
 	"github.com/lxc/distrobuilder/shared"
 )
 
-var lxdImageDef = shared.DefinitionImage{
-	Description:  "{{ image. Distribution|capfirst }} {{ image.Release }}",
-	Distribution: "ubuntu",
-	Release:      "17.10",
-	Architecture: "amd64",
-	Expiry:       "30d",
-	Name:         "{{ image.Distribution|lower }}-{{ image.Release }}-{{ image.Architecture }}-{{ image.Serial }}",
-	Serial:       "testing",
+var lxdDef = shared.Definition{
+	Image: shared.DefinitionImage{
+		Description:  "{{ image. distribution|capfirst }} {{ image.release }}",
+		Distribution: "ubuntu",
+		Release:      "17.10",
+		Architecture: "amd64",
+		Expiry:       "30d",
+		Name:         "{{ image.distribution|lower }}-{{ image.release }}-{{ image.arch }}-{{ image.serial }}",
+		Serial:       "testing",
+	},
 }
 
 func setupLXD(t *testing.T) *LXDImage {
@@ -37,7 +39,7 @@ func setupLXD(t *testing.T) *LXDImage {
 		t.Fatalf("Failed to create templates directory: %s", err)
 	}
 
-	image := NewLXDImage(cacheDir, "", cacheDir, lxdImageDef)
+	image := NewLXDImage(cacheDir, "", cacheDir, lxdDef)
 
 	// Check cache directory
 	if image.cacheDir != cacheDir {
@@ -45,9 +47,9 @@ func setupLXD(t *testing.T) *LXDImage {
 		t.Fatalf("Expected cacheDir to be '%s', is '%s'", cacheDir, image.cacheDir)
 	}
 
-	if !reflect.DeepEqual(lxdImageDef, image.definition) {
+	if !reflect.DeepEqual(lxdDef, image.definition) {
 		teardownLXD(t)
-		t.Fatal("lxdImageDef and image.definition are not equal")
+		t.Fatal("lxdDef and image.definition are not equal")
 	}
 
 	return image
@@ -98,7 +100,7 @@ func testLXDBuildUnifiedImage(t *testing.T, image *LXDImage) {
 	}
 
 	// Create unified tarball with default name.
-	image.definition.Name = ""
+	image.definition.Image.Name = ""
 	err = image.Build(true, "xz")
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
@@ -137,24 +139,24 @@ func TestLXDCreateMetadata(t *testing.T) {
 		{
 			"Properties[os]",
 			image.Metadata.Properties["os"],
-			lxdImageDef.Distribution,
+			lxdDef.Image.Distribution,
 		},
 		{
 			"Properties[release]",
 			image.Metadata.Properties["release"],
-			lxdImageDef.Release,
+			lxdDef.Image.Release,
 		},
 		{
 			"Properties[description]",
 			image.Metadata.Properties["description"],
-			fmt.Sprintf("%s %s", strings.Title(lxdImageDef.Distribution),
-				lxdImageDef.Release),
+			fmt.Sprintf("%s %s", strings.Title(lxdDef.Image.Distribution),
+				lxdDef.Image.Release),
 		},
 		{
 			"Properties[name]",
 			image.Metadata.Properties["name"],
-			fmt.Sprintf("%s-%s-%s-%s", strings.ToLower(lxdImageDef.Distribution),
-				lxdImageDef.Release, "x86_64", lxdImageDef.Serial),
+			fmt.Sprintf("%s-%s-%s-%s", strings.ToLower(lxdDef.Image.Distribution),
+				lxdDef.Image.Release, "x86_64", lxdDef.Image.Serial),
 		},
 	}
 

--- a/image/lxd_test.go
+++ b/image/lxd_test.go
@@ -16,7 +16,7 @@ import (
 
 var lxdDef = shared.Definition{
 	Image: shared.DefinitionImage{
-		Description:  "{{ image. distribution|capfirst }} {{ image.release }}",
+		Description:  "{{ image.distribution|capfirst }} {{ image. release }}",
 		Distribution: "ubuntu",
 		Release:      "17.10",
 		Architecture: "amd64",

--- a/image/lxd_test.go
+++ b/image/lxd_test.go
@@ -21,7 +21,7 @@ var lxdDef = shared.Definition{
 		Release:      "17.10",
 		Architecture: "amd64",
 		Expiry:       "30d",
-		Name:         "{{ image.distribution|lower }}-{{ image.release }}-{{ image.arch }}-{{ image.serial }}",
+		Name:         "{{ image.distribution|lower }}-{{ image.release }}-{{ image.architecture }}-{{ image.serial }}",
 		Serial:       "testing",
 	},
 }

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -24,7 +24,7 @@ type DefinitionImage struct {
 	Description  string `yaml:"description"`
 	Distribution string `yaml:"distribution"`
 	Release      string `yaml:"release,omitempty"`
-	Architecture string `yaml:"arch,omitempty"`
+	Architecture string `yaml:"architecture,omitempty"`
 	Expiry       string `yaml:"expiry,omitempty"`
 	Variant      string `yaml:"variant,omitempty"`
 	Name         string `yaml:"name,omitempty"`

--- a/shared/util.go
+++ b/shared/util.go
@@ -143,6 +143,8 @@ func CreateGPGKeyring(keyserver string, keys []string) (string, error) {
 func Pack(filename, compression, path string, args ...string) error {
 	err := RunCommand("tar", append([]string{"-cf", filename, "-C", path}, args...)...)
 	if err != nil {
+		// Clean up incomplete tarball
+		os.Remove(filename)
 		return err
 	}
 

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -119,13 +119,25 @@ func TestCreateGPGKeyring(t *testing.T) {
 func TestRenderTemplate(t *testing.T) {
 	tests := []struct {
 		name       string
-		context    pongo2.Context
+		iface      interface{}
 		template   string
 		expected   string
 		shouldFail bool
 	}{
 		{
-			"valid template",
+			"valid template with yaml tags",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "Ubuntu",
+					Release:      "Bionic",
+				},
+			},
+			"{{ image.distribution }} {{ image.release }}",
+			"Ubuntu Bionic",
+			false,
+		},
+		{
+			"valid template without yaml tags",
 			pongo2.Context{
 				"foo": "bar",
 			},
@@ -162,7 +174,7 @@ func TestRenderTemplate(t *testing.T) {
 
 	for i, tt := range tests {
 		log.Printf("Running test #%d: %s", i, tt.name)
-		ret, err := RenderTemplate(tt.template, tt.context)
+		ret, err := RenderTemplate(tt.template, tt.iface)
 		if tt.shouldFail && err == nil {
 			t.Fatal("test should have failed")
 		}


### PR DESCRIPTION
Use the yaml tags instead of the struct names in the templates.