### PR TITLE
<fix/typo: Fix a typo a code documentation>

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Project status  | CII Best Practices    | [![CII Best Practices](https://bestpra
 
 ## Example usage
 
-Save one of the [Ubuntu yaml snippets](./doc/examples/ubuntu.md) as
+Save one of the [Ubuntu yaml snippets](./doc/examples/ubuntu) as
 `ubuntu.yaml`. To create a simple `Ubuntu` rootfs in a folder called
 `ubuntu-rootfs` call `distrobuilder` as `distrobuilder build-dir ubuntu.yaml
 ubuntu-rootfs`.


### PR DESCRIPTION
Link to Ubuntu YAML example was suffixed by an '.md' which does not
reflect content of the examples directory.