### PR TITLE
main.go: Check for root user as the first thing in main

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -92,6 +92,17 @@ func main() {
 				fmt.Fprintf(os.Stderr, "You must be root to run this tool\n")
 				os.Exit(1)
 			}
+
+			// Create temp directory if the cache directory isn't explicitly set
+			if globalCmd.flagCacheDir == "" {
+				dir, err := ioutil.TempDir("/var/cache", "distrobuilder.")
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to create cache directory: %s\n", err)
+					os.Exit(1)
+				}
+
+				globalCmd.flagCacheDir = dir
+			}
 		},
 		PersistentPostRunE: globalCmd.postRun,
 	}
@@ -116,17 +127,6 @@ func main() {
 	// build-dir sub-command
 	buildDirCmd := cmdBuildDir{global: &globalCmd}
 	app.AddCommand(buildDirCmd.command())
-
-	// Create temp directory if the cache directory isn't explicitly set
-	if globalCmd.flagCacheDir == "" {
-		dir, err := ioutil.TempDir("/var/cache", "distrobuilder.")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create cache directory: %s\n", err)
-			os.Exit(1)
-		}
-
-		globalCmd.flagCacheDir = dir
-	}
 
 	// Run the main command and handle errors
 	err := app.Execute()


### PR DESCRIPTION
Just have a PersistentPreRun hook for cobra isn't enough, because right
before the app.Execute() we call ioutil.TempDir, which tries to create a
new distrory under /var/cache, so it fails as bellow:

distrobuilder help
Failed to create cache directory: mkdir /var/cache/distrobuilder.685166231: permission denied

By moving the check for root user as the first thing distrobuilder does
solves the problem.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>