### PR TITLE
Add systemd-sysvcompat as archlinux dependency

### DIFF
--- a/doc/examples/archlinux
+++ b/doc/examples/archlinux
@@ -55,4 +55,5 @@ packages:
 
   update: true
   install:
+    - systemd-sysvcompat
     - neovim


### PR DESCRIPTION
I tried building the archlinux example, but `lxc-start` failed due to `/sbin/init` being missing. I added `systemd-sysvcompat`, which provides `/sbin/init`, as a dependency.