### PR TITLE
main.go: Do not show help message if downloader.Run fails

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -136,6 +136,9 @@ func main() {
 }
 
 func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
+	// if an error is returned, disable the usage message
+	cmd.SilenceUsage = true
+
 	// Clean up cache directory before doing anything
 	os.RemoveAll(c.flagCacheDir)
 


### PR DESCRIPTION
Before this patch, if a user executes distrobuilder using the debian
example without having debootstrap installed, the following message is
returned:

Error: Error while downloading source: exec: "debootstrap": executable file not found in $PATH
Usage:
  distrobuilder build-dir <filename|-> <target dir> [flags]

Flags:
  -h, --help   help for build-dir

Global Flags:
      --cache-dir   Cache directory
      --cleanup     Clean up cache directory (default true)
  -o, --options     Override options (list of key=value)

This happens because distrobuilder subcommands uses cobra's RunE or PreRunE,
so if an error is returned, the help message is shown.

In order to avoid this message, execute os.Exit(1) when downloader.Run fails:

Error: Error while downloading source: exec: "debootstrap": executable file not found in $PATH

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>