### PR TITLE
Export function DownloadHash

### DIFF
--- a/sources/alpine-http.go
+++ b/sources/alpine-http.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/url"
@@ -62,9 +63,9 @@ func (s *AlpineLinuxHTTP) Run(definition shared.Definition, rootfsDir string) er
 	}
 
 	if definition.Source.SkipVerification {
-		err = shared.DownloadSha256(tarball, "")
+		err = shared.DownloadHash(tarball, "", nil)
 	} else {
-		err = shared.DownloadSha256(tarball, tarball+".sha256")
+		err = shared.DownloadHash(tarball, tarball+".sha256", sha256.New())
 	}
 	if err != nil {
 		return err
@@ -72,7 +73,7 @@ func (s *AlpineLinuxHTTP) Run(definition shared.Definition, rootfsDir string) er
 
 	// Force gpg checks when using http
 	if !definition.Source.SkipVerification && url.Scheme != "https" {
-		shared.DownloadSha256(tarball+".asc", "")
+		shared.DownloadHash(tarball+".asc", "", nil)
 		valid, err := shared.VerifyFile(
 			filepath.Join(os.TempDir(), fname),
 			filepath.Join(os.TempDir(), fname+".asc"),

--- a/sources/archlinux-http.go
+++ b/sources/archlinux-http.go
@@ -38,14 +38,14 @@ func (s *ArchLinuxHTTP) Run(definition shared.Definition, rootfsDir string) erro
 		return errors.New("GPG keys are required if downloading from HTTP")
 	}
 
-	err = shared.DownloadSha256(tarball, "")
+	err = shared.DownloadHash(tarball, "", nil)
 	if err != nil {
 		return err
 	}
 
 	// Force gpg checks when using http
 	if !definition.Source.SkipVerification && url.Scheme != "https" {
-		shared.DownloadSha256(tarball+".sig", "")
+		shared.DownloadHash(tarball+".sig", "", nil)
 
 		valid, err := shared.VerifyFile(
 			filepath.Join(os.TempDir(), fname),

--- a/sources/centos-http.go
+++ b/sources/centos-http.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -53,7 +54,7 @@ func (s *CentOSHTTP) Run(definition shared.Definition, rootfsDir string) error {
 			}
 
 			checksumFile = "sha256sum.txt.asc"
-			shared.DownloadSha256(baseURL+checksumFile, "")
+			shared.DownloadHash(baseURL+checksumFile, "", nil)
 			valid, err := shared.VerifyFile(filepath.Join(os.TempDir(), checksumFile), "",
 				definition.Source.Keys, definition.Source.Keyserver)
 			if err != nil {
@@ -65,7 +66,7 @@ func (s *CentOSHTTP) Run(definition shared.Definition, rootfsDir string) error {
 		}
 	}
 
-	err = shared.DownloadSha256(baseURL+s.fname, checksumFile)
+	err = shared.DownloadHash(baseURL+s.fname, checksumFile, sha256.New())
 	if err != nil {
 		return fmt.Errorf("Error downloading CentOS image: %s", err)
 	}

--- a/sources/fedora-http.go
+++ b/sources/fedora-http.go
@@ -41,8 +41,8 @@ func (s *FedoraHTTP) Run(definition shared.Definition, rootfsDir string) error {
 		definition.Image.Release, build, definition.Image.ArchitectureMapped)
 
 	// Download image
-	err = shared.DownloadSha256(fmt.Sprintf("%s/%s/%s/images/%s",
-		baseURL, definition.Image.Release, build, fname), "")
+	err = shared.DownloadHash(fmt.Sprintf("%s/%s/%s/images/%s",
+		baseURL, definition.Image.Release, build, fname), "", nil)
 	if err != nil {
 		return err
 	}

--- a/sources/gentoo.go
+++ b/sources/gentoo.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -50,9 +51,9 @@ func (s *GentooHTTP) Run(definition shared.Definition, rootfsDir string) error {
 	}
 
 	if definition.Source.SkipVerification {
-		err = shared.DownloadSha512(tarball, "")
+		err = shared.DownloadHash(tarball, "", nil)
 	} else {
-		err = shared.DownloadSha512(tarball, tarball+".DIGESTS")
+		err = shared.DownloadHash(tarball, tarball+".DIGESTS", sha512.New())
 	}
 	if err != nil {
 		return err
@@ -60,7 +61,7 @@ func (s *GentooHTTP) Run(definition shared.Definition, rootfsDir string) error {
 
 	// Force gpg checks when using http
 	if !definition.Source.SkipVerification && url.Scheme != "https" {
-		shared.DownloadSha512(tarball+".DIGESTS.asc", "")
+		shared.DownloadHash(tarball+".DIGESTS.asc", "", nil)
 		valid, err := shared.VerifyFile(
 			filepath.Join(os.TempDir(), fname+".DIGESTS.asc"),
 			"",

--- a/sources/ubuntu-http.go
+++ b/sources/ubuntu-http.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -57,8 +58,8 @@ func (s *UbuntuHTTP) Run(definition shared.Definition, rootfsDir string) error {
 		}
 
 		checksumFile = baseURL + "SHA256SUMS"
-		shared.DownloadSha256(baseURL+"SHA256SUMS.gpg", "")
-		shared.DownloadSha256(checksumFile, "")
+		shared.DownloadHash(baseURL+"SHA256SUMS.gpg", "", nil)
+		shared.DownloadHash(checksumFile, "", nil)
 
 		valid, err := shared.VerifyFile(
 			filepath.Join(os.TempDir(), "SHA256SUMS"),
@@ -73,7 +74,7 @@ func (s *UbuntuHTTP) Run(definition shared.Definition, rootfsDir string) error {
 		}
 	}
 
-	err = shared.DownloadSha256(baseURL+s.fname, checksumFile)
+	err = shared.DownloadHash(baseURL+s.fname, checksumFile, sha256.New())
 	if err != nil {
 		return fmt.Errorf("Error downloading Ubuntu image: %s", err)
 	}


### PR DESCRIPTION
This removes the functions `DownloadSha{256,512}` in favor of the more general function `DownloadHash` which let's you specify a hash function.