### PR TITLE
sources: Remove temporary root directory in Arch

### DIFF
--- a/sources/archlinux-http.go
+++ b/sources/archlinux-http.go
@@ -81,6 +81,6 @@ func (s *ArchLinuxHTTP) Run(definition shared.Definition, rootfsDir string) erro
 		}
 	}
 
-	return os.RemoveAll(filepath.Join(rootfsDir, "root",
+	return os.RemoveAll(filepath.Join(rootfsDir, "root."+
 		definition.Image.ArchitectureMapped))
 }


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>