### PR TITLE
sources: Get latest Arch Linux release by default

### DIFF
--- a/sources/archlinux-http_test.go
+++ b/sources/archlinux-http_test.go
@@ -1,0 +1,16 @@
+package sources
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchLinuxGetLatestRelease(t *testing.T) {
+	var src ArchLinuxHTTP
+
+	release, err := src.getLatestRelease()
+	require.NoError(t, err)
+	require.Regexp(t, regexp.MustCompile(`^\d{4}\.\d{2}\.\d{2}$`), release)
+}


### PR DESCRIPTION
If image.release is empty or not set, the latest release will be used.

This resolves #126.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>