### PR TITLE
Add Plamo Linux

### DIFF
--- a/distrobuilder/chroot.go
+++ b/distrobuilder/chroot.go
@@ -12,10 +12,15 @@ import (
 func managePackages(def shared.DefinitionPackages, actions []shared.DefinitionAction,
 	release string, architecture string) error {
 	var err error
+	var manager *managers.Manager
 
-	manager := managers.Get(def.Manager)
-	if manager == nil {
-		return fmt.Errorf("Couldn't get manager")
+	if def.Manager != "" {
+		manager = managers.Get(def.Manager)
+		if manager == nil {
+			return fmt.Errorf("Couldn't get manager")
+		}
+	} else {
+		manager = managers.GetCustom(*def.CustomManager)
 	}
 
 	// Handle repositories actions

--- a/doc/examples/plamolinux
+++ b/doc/examples/plamolinux
@@ -1,0 +1,123 @@
+image:
+  distribution: plamolinux
+  release: 7
+  description: Plamo Linux
+  expiry: 30d
+  architecture: x86_64
+
+source:
+  downloader: plamolinux-http
+  url: https://repository.plamolinux.org/pub/linux/Plamo
+
+targets:
+  lxc:
+    create-message: |
+      You just created a Plamo Linux container (release={{ image.release }}, arch={{ image.architecture }})
+
+    config:
+      - type: all
+        before: 5
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/plamolinux.common.conf
+
+      - type: user
+        before: 5
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/plamolinux.userns.conf
+
+      - type: all
+        after: 4
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/common.conf
+
+      - type: user
+        after: 4
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/userns.conf
+
+      - type: all
+        content: |-
+          lxc.arch = {{ image.architecture_kernel }}
+
+files:
+  - name: hostname
+    path: /etc/hostname
+    generator: hostname
+
+  - name: hosts
+    path: /etc/hosts
+    generator: hosts
+
+packages:
+  custom-manager:
+    install:
+      cmd: installpkg
+    remove:
+      cmd: removepkg
+    update:
+      cmd: updatepkg
+    clean:
+      cmd: true 
+    refresh:
+      cmd: true
+
+actions:
+  - trigger: post-unpack
+    action: |
+      #!/bin/sh
+      # fstab
+      cat <<- "EOF" >> /etc/fstab
+      proc            /proc   proc    defaults        0 0
+      tmpfs           /run    tmpfs   defaults        0 0
+      sysfs           /sys    sysfs   defaults        0 0
+      tmpfs           /tmp    tmpfs   defaults        0 0
+      devpts          /dev/pts        devpts  gid=5,mode=620  0 0
+      usbfs           /proc/bus/usb   usbfs   noauto  0 0
+      EOF
+
+      # inittab
+      sed -i -e '/^1:2345/i c:1235:respawn:/sbin/agetty console 38400'\
+          -e '/^ca:/a pf::powerfail:/sbin/shutdown -h +0 "THE POWER IS FAILING"' \
+          -e '/^4:2345/d' \
+          -e '/^5:2345/d' \
+          -e '/^6:2345/d' /etc/inittab
+
+      # tweak init script on startup
+      remove_init_S="S05modules S10eudev S20swap S30checkfs S35setclock S50eudev_retry S70console"
+      for f in $remove_init_S
+      do
+        rm -f /etc/rc.d/rcS.d/"$f"
+      done
+
+      # remove init script in runlevel3
+      remove_init="rc3.d/S30sshd
+                  rc6.d/K30sshd rc6.d/K35setclock rc6.d/S65swap rc6.d/S70mountfs
+                  rc0.d/K30sshd rc0.d/K35setclock rc0.d/S65swap rc0.d/S70mountfs"
+      for f in $remove_init
+      do
+        rm -f /etc/rc.d/"$f"
+      done
+
+      # Tweak rc script
+      sed -i -e '/wait_for_user/d' \
+          -e '/Press Enter to/d' \
+          /etc/rc.d/init.d/rc
+
+      # network
+      cat <<- "EOF" > /etc/sysconfig/ifconfig.eth0
+      ONBOOT="yes"
+      IFACE="eth0"
+      SERVICE="dhclient"
+      EOF
+
+      # initpkg
+      noexec="shadow netconfig7 eudev openssh"
+      for f in $noexec
+      do
+        rm -f /var/log/initpkg/"$f"
+      done
+
+      for f in /var/log/initpkg/*
+      do
+        sh $f
+      done

--- a/managers/apk.go
+++ b/managers/apk.go
@@ -3,7 +3,13 @@ package managers
 // NewApk creates a new Manager instance.
 func NewApk() *Manager {
 	return &Manager{
-		command: "apk",
+		commands: ManagerCommands{
+			clean:   "apk",
+			install: "apk",
+			refresh: "apk",
+			remove:  "apk",
+			update:  "apk",
+		},
 		flags: ManagerFlags{
 			global: []string{
 				"--no-cache",

--- a/managers/apt.go
+++ b/managers/apt.go
@@ -3,7 +3,13 @@ package managers
 // NewApt creates a new Manager instance.
 func NewApt() *Manager {
 	return &Manager{
-		command: "apt-get",
+		commands: ManagerCommands{
+			clean:   "apt-get",
+			install: "apt-get",
+			refresh: "apt-get",
+			remove:  "apt-get",
+			update:  "apt-get",
+		},
 		flags: ManagerFlags{
 			clean: []string{
 				"clean",

--- a/managers/dnf.go
+++ b/managers/dnf.go
@@ -3,7 +3,13 @@ package managers
 // NewDnf creates a new Manager instance.
 func NewDnf() *Manager {
 	return &Manager{
-		command: "dnf",
+		commands: ManagerCommands{
+			clean:   "dnf",
+			install: "dnf",
+			refresh: "dnf",
+			remove:  "dnf",
+			update:  "dnf",
+		},
 		flags: ManagerFlags{
 			global: []string{
 				"-y",

--- a/managers/equo.go
+++ b/managers/equo.go
@@ -40,7 +40,13 @@ func equoRepoCaller(repo shared.DefinitionPackagesRepository) error {
 // NewEquo creates a new Manager instance
 func NewEquo() *Manager {
 	return &Manager{
-		command: "equo",
+		commands: ManagerCommands{
+			clean:   "equo",
+			install: "equo",
+			refresh: "equo",
+			remove:  "equo",
+			update:  "equo",
+		},
 		flags: ManagerFlags{
 			global: []string{},
 			clean: []string{

--- a/managers/pacman.go
+++ b/managers/pacman.go
@@ -26,7 +26,13 @@ func NewPacman() *Manager {
 	}
 
 	return &Manager{
-		command: "pacman",
+		commands: ManagerCommands{
+			clean:   "pacman",
+			install: "pacman",
+			refresh: "pacman",
+			remove:  "pacman",
+			update:  "pacman",
+		},
 		flags: ManagerFlags{
 			clean: []string{
 				"-Sc",

--- a/managers/portage.go
+++ b/managers/portage.go
@@ -3,7 +3,13 @@ package managers
 // NewPortage creates a new Manager instance.
 func NewPortage() *Manager {
 	return &Manager{
-		command: "emerge",
+		commands: ManagerCommands{
+			clean:   "emerge",
+			install: "emerge",
+			refresh: "emerge",
+			remove:  "emerge",
+			update:  "emerge",
+		},
 		flags: ManagerFlags{
 			global: []string{},
 			clean:  []string{},

--- a/managers/yum.go
+++ b/managers/yum.go
@@ -3,7 +3,13 @@ package managers
 // NewYum creates a new Manager instance.
 func NewYum() *Manager {
 	return &Manager{
-		command: "yum",
+		commands: ManagerCommands{
+			clean:   "yum",
+			install: "yum",
+			refresh: "yum",
+			remove:  "yum",
+			update:  "yum",
+		},
 		flags: ManagerFlags{
 			clean: []string{
 				"clean", "all",

--- a/managers/zypper.go
+++ b/managers/zypper.go
@@ -3,7 +3,13 @@ package managers
 // NewZypper create a new Manager instance.
 func NewZypper() *Manager {
 	return &Manager{
-		command: "zypper",
+		commands: ManagerCommands{
+			clean:   "zypper",
+			install: "zypper",
+			refresh: "zypper",
+			remove:  "zypper",
+			update:  "zypper",
+		},
 		flags: ManagerFlags{
 			global: []string{
 				"--non-interactive",

--- a/shared/definition_test.go
+++ b/shared/definition_test.go
@@ -89,6 +89,39 @@ func TestValidateDefinition(t *testing.T) {
 			false,
 		},
 		{
+			"valid Defintion with packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{
+						Install: CustomManagerCmd{
+							Command: "install",
+						},
+						Remove: CustomManagerCmd{
+							Command: "remove",
+						},
+						Clean: CustomManagerCmd{
+							Command: "clean",
+						},
+						Update: CustomManagerCmd{
+							Command: "update",
+						},
+						Refresh: CustomManagerCmd{
+							Command: "refresh",
+						},
+					},
+				},
+			},
+			"",
+			false,
+		},
+		{
 			"invalid ArchitectureMap",
 			Definition{
 				Image: DefinitionImage{
@@ -176,6 +209,172 @@ func TestValidateDefinition(t *testing.T) {
 				},
 			},
 			"packages.manager must be one of .+",
+			true,
+		},
+		{
+			"missing clean command in packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{},
+				},
+			},
+			"packages.custom-manager requires a clean command",
+			true,
+		},
+		{
+			"missing install command in packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{
+						Clean: CustomManagerCmd{
+							Command: "clean",
+						},
+					},
+				},
+			},
+			"packages.custom-manager requires an install command",
+			true,
+		},
+		{
+			"missing remove command in packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{
+						Clean: CustomManagerCmd{
+							Command: "clean",
+						},
+						Install: CustomManagerCmd{
+							Command: "install",
+						},
+					},
+				},
+			},
+			"packages.custom-manager requires a remove command",
+			true,
+		},
+		{
+			"missing refresh command in packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{
+						Clean: CustomManagerCmd{
+							Command: "clean",
+						},
+						Install: CustomManagerCmd{
+							Command: "install",
+						},
+						Remove: CustomManagerCmd{
+							Command: "remove",
+						},
+					},
+				},
+			},
+			"packages.custom-manager requires a refresh command",
+			true,
+		},
+		{
+			"missing update command in packages.custom-manager",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					CustomManager: &DefinitionPackagesCustomManager{
+						Clean: CustomManagerCmd{
+							Command: "clean",
+						},
+						Install: CustomManagerCmd{
+							Command: "install",
+						},
+						Remove: CustomManagerCmd{
+							Command: "remove",
+						},
+						Refresh: CustomManagerCmd{
+							Command: "refresh",
+						},
+					},
+				},
+			},
+			"packages.custom-manager requires an update command",
+			true,
+		},
+		{
+			"package.manager and package.custom-manager set",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{
+					Manager:       "apt",
+					CustomManager: &DefinitionPackagesCustomManager{},
+				},
+			},
+			"cannot have both packages.manager and packages.custom-manager set",
+			true,
+		},
+		{
+			"package.manager and package.custom-manager unset",
+			Definition{
+				Image: DefinitionImage{
+					Distribution: "ubuntu",
+					Release:      "artful",
+				},
+				Source: DefinitionSource{
+					Downloader: "debootstrap",
+					URL:        "https://ubuntu.com",
+					Keys:       []string{"0xCODE"},
+				},
+				Packages: DefinitionPackages{},
+			},
+			"packages.manager or packages.custom-manager needs to be set",
 			true,
 		},
 		{

--- a/sources/plamolinux-http.go
+++ b/sources/plamolinux-http.go
@@ -1,0 +1,137 @@
+package sources
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/antchfx/htmlquery.v1"
+
+	"github.com/lxc/distrobuilder/shared"
+)
+
+// PlamoLinuxHTTP represents the Plamo Linux downloader.
+type PlamoLinuxHTTP struct {
+}
+
+// NewPlamoLinuxHTTP creates a new PlamoLinuxHTTP instance.
+func NewPlamoLinuxHTTP() *PlamoLinuxHTTP {
+	return &PlamoLinuxHTTP{}
+}
+
+// Run downloads Plamo Linux.
+func (s *PlamoLinuxHTTP) Run(definition shared.Definition, rootfsDir string) error {
+	release, err := strconv.Atoi(definition.Image.Release)
+	if err != nil {
+		return fmt.Errorf("Failed to determine release: %v", err)
+	}
+
+	u, err := url.Parse(definition.Source.URL)
+	if err != nil {
+		return err
+	}
+
+	mirrorPath := path.Join(u.Path, fmt.Sprintf("Plamo-%s.x", definition.Image.Release),
+		definition.Image.ArchitectureMapped, "plamo")
+
+	paths := []string{
+		path.Join(mirrorPath, "00_base"),
+	}
+
+	if release < 7 {
+		paths = append(paths, path.Join(mirrorPath, "01_minimum"))
+
+	}
+
+	var pkgDir string
+
+	for _, p := range paths {
+		u.Path = p
+
+		pkgDir, err = s.downloadFiles(definition.Image, u.String())
+		if err != nil {
+			return fmt.Errorf("Failed to download packages: %v", err)
+		}
+	}
+
+	var pkgTool string
+
+	// Find package tool
+	if release < 7 {
+		pkgTool = "hdsetup"
+	} else {
+		pkgTool = "pkgtools"
+	}
+
+	matches, err := filepath.Glob(filepath.Join(pkgDir, fmt.Sprintf("%s-*.txz", pkgTool)))
+	if err != nil {
+		return err
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("Couldn't find any matching package")
+	} else if len(matches) > 1 {
+		return fmt.Errorf("Found more than one matching package")
+	}
+
+	err = shared.RunCommand("tar", "-pxJf", matches[0], "-C", pkgDir, "sbin/")
+	if err != nil {
+		return err
+	}
+
+	return shared.RunScript(fmt.Sprintf(`#!/bin/sh
+
+dlcache=%s
+rootfs_dir=%s
+
+sed -i "/ldconfig/!s@/sbin@$dlcache&@g" $dlcache/sbin/installpkg*
+PATH=$dlcache/sbin:$PATH
+export LC_ALL=C LANG=C
+
+for p in $(ls -cr $dlcache/*.t?z) ; do
+    installpkg -root $rootfs_dir -priority ADD $p
+done
+`, pkgDir, rootfsDir))
+}
+
+func (s *PlamoLinuxHTTP) downloadFiles(def shared.DefinitionImage, URL string) (string, error) {
+	doc, err := htmlquery.LoadURL(URL)
+	if err != nil {
+		return "", err
+	}
+
+	if doc == nil {
+		return "", fmt.Errorf("Failed to load URL")
+	}
+
+	nodes := htmlquery.Find(doc, `//a/@href`)
+
+	var dir string
+
+	for _, n := range nodes {
+		target := htmlquery.InnerText(n)
+
+		if strings.HasSuffix(target, ".txz") {
+			// package
+			dir, err = shared.DownloadHash(def, fmt.Sprintf("%s/%s", URL, target), "", nil)
+			if err != nil {
+				return "", err
+			}
+		} else if strings.HasSuffix(target, ".txz/") {
+			// directory
+			u, err := url.Parse(URL)
+			if err != nil {
+				return "", err
+			}
+
+			u.Path = path.Join(u.Path, target)
+
+			return s.downloadFiles(def, u.String())
+		}
+	}
+
+	return dir, nil
+}

--- a/sources/source.go
+++ b/sources/source.go
@@ -32,6 +32,8 @@ func Get(name string) Downloader {
 		return NewOracleLinuxHTTP()
 	case "opensuse-http":
 		return NewOpenSUSEHTTP()
+	case "plamolinux-http":
+		return NewPlamoLinuxHTTP()
 	}
 
 	return nil


### PR DESCRIPTION
Plamo Linux uses multiple scripts for managing packages. This required some changes in the managers code, so now we can specify custom managers (see Plamo Linux example).

Package management itself still needs to be addressed here. It seems as though one would have to download every package manually and install it. This is somewhat cumbersome.

However, this creates an almost complete rootfs. The `tar` command used by `installpkg` won't install packages containing files with the sticky bit for example. This affects only three packages AFAICT. It shouldn't be a problem though since this issue would also exist in the current lxc-template which I assume is fine.

