### PR TITLE
shared: Use RunCommandSplit for GPG

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -152,7 +152,7 @@ func recvGPGKeys(gpgDir string, keyserver string, keys []string) (bool, error) {
 
 	args = append(args, append([]string{"--recv-keys"}, fingerprints...)...)
 
-	out, err := lxd.TryRunCommand("gpg", args...)
+	_, out, err := lxd.RunCommandSplit("gpg", args...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This should fix #197

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>