### PR TITLE
shared: Fix args of RunCommandSplit

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -152,7 +152,7 @@ func recvGPGKeys(gpgDir string, keyserver string, keys []string) (bool, error) {
 
 	args = append(args, append([]string{"--recv-keys"}, fingerprints...)...)
 
-	_, out, err := lxd.RunCommandSplit(nil, "gpg", args...)
+	_, out, err := lxd.RunCommandSplit("gpg", args...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>