### PR TITLE
shared: Remove source.ignore_release

### DIFF
--- a/shared/definition.go
+++ b/shared/definition.go
@@ -89,7 +89,6 @@ type DefinitionSource struct {
 	Suite            string   `yaml:"suite,omitempty"`
 	SameAs           string   `yaml:"same_as,omitempty"`
 	AptSources       string   `yaml:"apt_sources,omitempty"`
-	IgnoreRelease    bool     `yaml:"ignore_release,omitempty"`
 	SkipVerification bool     `yaml:"skip_verification,omitempty"`
 	EarlyPackages    []string `yaml:"early_packages,omitempty"`
 }

--- a/shared/definition_test.go
+++ b/shared/definition_test.go
@@ -447,10 +447,10 @@ func TestDefinitionSetValue(t *testing.T) {
 			Release:      "artful",
 		},
 		Source: DefinitionSource{
-			Downloader:    "debootstrap",
-			URL:           "https://ubuntu.com",
-			Keys:          []string{"0xCODE"},
-			IgnoreRelease: true,
+			Downloader:       "debootstrap",
+			URL:              "https://ubuntu.com",
+			Keys:             []string{"0xCODE"},
+			SkipVerification: true,
 		},
 		Packages: DefinitionPackages{
 			Manager: "apt",
@@ -483,9 +483,9 @@ func TestDefinitionSetValue(t *testing.T) {
 	err = d.SetValue("image", "[foo: bar]")
 	require.EqualError(t, err, "Unsupported type 'struct'")
 
-	err = d.SetValue("source.ignore_release", "true")
+	err = d.SetValue("source.skip_verification", "true")
 	require.NoError(t, err)
-	require.Equal(t, true, d.Source.IgnoreRelease)
+	require.Equal(t, true, d.Source.SkipVerification)
 }
 
 func TestDefinitionFilter(t *testing.T) {

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -52,16 +52,11 @@ func (s *Debootstrap) Run(definition shared.Definition, rootfsDir string) error 
 		args = append(args, "--keyring", keyring)
 	}
 
-	// If source.ignore_release is set, debootstrap will not use image.release
-	// but source.suite as the release. This is important for derivatives which
-	// don't have own sources, e.g. Linux Mint.
-	if definition.Source.IgnoreRelease {
-		// If source.suite is set, use it when calling debootstrap
-		if definition.Source.Suite != "" {
-			args = append(args, definition.Source.Suite, rootfsDir)
-		} else {
-			args = append(args, definition.Image.Release, rootfsDir)
-		}
+	// If source.suite is set, debootstrap will use this instead of
+	// image.release as its first positional argument (SUITE). This is important
+	// for derivatives which don't have their own sources, e.g. Linux Mint.
+	if definition.Source.Suite != "" {
+		args = append(args, definition.Source.Suite, rootfsDir)
 	} else {
 		args = append(args, definition.Image.Release, rootfsDir)
 	}
@@ -71,7 +66,7 @@ func (s *Debootstrap) Run(definition shared.Definition, rootfsDir string) error 
 	}
 
 	// If definition.Source.SameAs is set, create a symlink in /usr/share/debootstrap/scripts
-	// pointing release to definition.Source.Suite.
+	// pointing release to definition.Source.SameAs.
 	scriptPath := filepath.Join("/usr/share/debootstrap/scripts", definition.Image.Release)
 	if !lxd.PathExists(scriptPath) && definition.Source.SameAs != "" {
 		err := os.Symlink(definition.Source.SameAs, scriptPath)


### PR DESCRIPTION
This field is useless as we can simply check source.suite.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>