### PR TITLE
sources: Run OpenWrt correctly

### DIFF
--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -103,8 +104,134 @@ func (s *OpenWrtHTTP) Run(definition shared.Definition, rootfsDir string) error 
 		return err
 	}
 
+	sdk := s.getSDK(baseURL, release)
+	if sdk == "" {
+		return fmt.Errorf("Failed to find SDK")
+	}
+
+	_, err = shared.DownloadHash(definition.Image, baseURL+sdk, checksumFile, sha256.New())
+	if err != nil {
+		return err
+	}
+
+	_, err = shared.DownloadHash(definition.Image, "https://github.com/mikma/lxd-openwrt/archive/master.tar.gz", "", sha256.New())
+	if err != nil {
+		return err
+	}
+
+	tempScriptsDir := filepath.Join(os.TempDir(), "distrobuilder", "fixes", "lxd-openwrt-master")
+	tempSDKDir := filepath.Join(tempScriptsDir, "build_dir")
+
+	os.MkdirAll(tempSDKDir, 0755)
+	os.MkdirAll(tempScriptsDir, 0755)
+	defer os.RemoveAll(filepath.Join(os.TempDir(), "distrobuilder"))
+
 	// Unpack
 	err = lxd.Unpack(filepath.Join(fpath, fname), rootfsDir, false, false, nil)
+	if err != nil {
+		return err
+	}
+
+	err = lxd.Unpack(filepath.Join(fpath, "master.tar.gz"), filepath.Join(os.TempDir(), "distrobuilder", "fixes"), false, false, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to unpack scripts: %v", err)
+	}
+
+	err = lxd.Unpack(filepath.Join(fpath, sdk), tempSDKDir, false, false, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to unpack SDK: %v", err)
+	}
+
+	// Set environment used in the lxd-openwrt scripts
+	os.Setenv("OPENWRT_ROOTFS", filepath.Join(fpath, fname))
+	os.Setenv("OPENWRT_ROOTFS_DIR", rootfsDir)
+	os.Setenv("OPENWRT_SDK", fmt.Sprintf("build_dir/%s", strings.TrimSuffix(sdk, ".tar.xz")))
+	os.Setenv("OPENWRT_ARCH", definition.Image.Architecture)
+	os.Setenv("OPENWRT_VERSION", release)
+
+	diff := `diff --git a/build.sh b/build.sh
+index 2347d05..eebb515 100755
+--- a/build.sh
++++ b/build.sh
+@@ -2,8 +2,8 @@
+
+ set -e
+
+-arch_lxd=x86_64
+-ver=18.06.4
++arch_lxd=${OPENWRT_ARCH}
++ver=${OPENWRT_VERSION}
+ dist=openwrt
+ type=lxd
+ super=fakeroot
+@@ -13,6 +13,9 @@ packages=iptables-mod-checksum
+ # Workaround for Debian/Ubuntu systems which use C.UTF-8 which is nsupported by OpenWrt
+ export LC_ALL=C
+
++readonly rootfs=${OPENWRT_ROOTFS}
++readonly sdk=${OPENWRT_SDK}
++
+ usage() {
+	 echo "Usage: $0 [-a|--arch x86_64|i686|aarch64] [-v|--version version>] [-p|--packages <packages>] [-f|--files] [-t|--type lxd|lain] [-s|--super fakeroot|sudo] [--help]"
+	 exit 1
+@@ -289,8 +292,6 @@ EOF
+ #     template: hostname.tpl
+ }
+
+-download_rootfs
+-download_sdk
+ if need_procd; then
+	 download_procd
+	 build_procd
+diff --git a/scripts/build_rootfs.sh b/scripts/build_rootfs.sh
+index b7ee533..e89379f 100755
+--- a/scripts/build_rootfs.sh
++++ b/scripts/build_rootfs.sh
+@@ -52,9 +52,9 @@ fi
+
+ src_tar=$1
+ base=` + "`basename $src_tar`" + `
+-dir=/tmp/build.$$
++dir=/tmp/distrobuilder
+ files_dir=files/
+-instroot=$dir/rootfs
++instroot=${OPENWRT_ROOTFS_DIR}
+ cache=dl/packages/$arch/$subarch
+
+ test -e $cache || mkdir -p $cache
+@@ -158,7 +158,6 @@ create_manifest() {
+	 $OPKG list-installed > $instroot/etc/openwrt_manifest
+ }
+
+-unpack
+ disable_root
+ if test -n "$metadata"; then
+	 add_file $metadata $metadata_dir $dir
+@@ -175,5 +174,3 @@ if test -n "$files"; then
+	 add_files $files $instroot
+ fi
+ create_manifest
+-pack
+-#pack_squashfs
+`
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(tempScriptsDir)
+	if err != nil {
+		return err
+	}
+
+	err = lxd.RunCommandWithFds(bytes.NewBufferString(diff), os.Stdout, "patch", "-p1")
+	if err != nil {
+		return err
+	}
+
+	_, err = lxd.RunCommand("sh", "build.sh")
 	if err != nil {
 		return err
 	}
@@ -127,6 +254,36 @@ func (s *OpenWrtHTTP) getLatestServiceRelease(baseURL, release string) string {
 	}
 
 	regex := regexp.MustCompile(fmt.Sprintf(">(%s\\.\\d+)<", release))
+	releases := regex.FindAllStringSubmatch(string(body), -1)
+
+	if len(releases) > 0 {
+		return releases[len(releases)-1][1]
+	}
+
+	return ""
+}
+
+func (s *OpenWrtHTTP) getSDK(baseURL, release string) string {
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return ""
+	}
+
+	if release == "snapshot" {
+		release = ""
+	} else {
+		release = fmt.Sprintf("-%s", release)
+	}
+
+	regex := regexp.MustCompile(fmt.Sprintf(">(openwrt-sdk%s-.*\\.tar\\.xz)<", release))
 	releases := regex.FindAllStringSubmatch(string(body), -1)
 
 	if len(releases) > 0 {


### PR DESCRIPTION
This fixes connectivity issues, and makes OpenWrt more usable.
The build.sh [1] script uses subversion which makes it a new dependency
of distrobuilder.

[1] https://github.com/mikma/lxd-openwrt

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>