### PR TITLE
managers: Add --allow-downgrade to zypper

### DIFF
--- a/distrobuilder/chroot.go
+++ b/distrobuilder/chroot.go
@@ -69,11 +69,6 @@ func managePackages(def shared.DefinitionPackages, actions []shared.DefinitionAc
 		}
 	}
 
-	// TODO: Remove this once openSUSE builds properly without it. OpenSUSE 42.3 doesn't support this flag.
-	if def.Manager == "zypper" && release != "42.3" {
-		manager.SetInstallFlags("install", "--allow-downgrade")
-	}
-
 	var validSets []shared.DefinitionPackagesSet
 
 	for _, set := range def.Sets {

--- a/managers/zypper.go
+++ b/managers/zypper.go
@@ -39,6 +39,7 @@ func NewZypper() *Manager {
 			},
 			install: []string{
 				"install",
+				"--allow-downgrade",
 			},
 			remove: []string{
 				"remove",


### PR DESCRIPTION
Remove the special case of openSUSE 42.3 and the `--allow-downgrade`
flag. Since openSUSE 42.3 is EOL, we can drop support for it.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>