### PR TITLE
Fix syntax in documentation for custom-manager

### DIFF
--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -137,7 +137,7 @@ packages:
       flags:
         - update
     flags:
-      --yes
+      - --yes
   update: true
   cleanup: false
   sets:

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -50,21 +50,21 @@ This is useful if the desired package manager is not supported by distrobuilder.
 packages:
     custom-manager: # required
         clean: # required
-            command: <string>
+            cmd: <string>
             flags: <array>
         install: # required
-            command: <string>
+            cmd: <string>
             flags: <array>
         remove: # required
-            command: <string>
+            cmd: <string>
             flags: <array>
         refresh: # required
-            command: <string>
+            cmd: <string>
             flags: <array>
         update: # required
-            command: <string>
+            cmd: <string>
             flags: <array>
-    flags: <array>
+        flags: <array> # global flags for all commands
     ...
 ```
 


### PR DESCRIPTION
This cleans up the docs and the example scheme.yaml file for the
"custom-manager" option.

Signed-off-by: Eddy Gurney <github@eddyg.promessage.com>