### PR TITLE
distrobuilder: Extend pongo2 template usage

### DIFF
--- a/distrobuilder/chroot.go
+++ b/distrobuilder/chroot.go
@@ -30,6 +30,12 @@ func manageRepositories(def *shared.Definition, manager *managers.Manager) error
 			return err
 		}
 
+		// Run template on repo.Key
+		repo.Key, err = shared.RenderTemplate(repo.Key, def)
+		if err != nil {
+			return err
+		}
+
 		err = manager.RepoHandler(repo)
 		if err != nil {
 			return fmt.Errorf("Error for repository %s: %s", repo.Name, err)

--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -236,6 +236,14 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Unsupported source downloader: %s", c.definition.Source.Downloader)
 	}
 
+	// Run template on source keys
+	for i, key := range c.definition.Source.Keys {
+		c.definition.Source.Keys[i], err = shared.RenderTemplate(key, c.definition)
+		if err != nil {
+			return fmt.Errorf("Failed to render source keys: %s", err)
+		}
+	}
+
 	// Download the root filesystem
 	err = downloader.Run(*c.definition, c.sourceDir)
 	if err != nil {


### PR DESCRIPTION
This enables rendering of source keys as well as repository keys.

This closed #258.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>