### PR TITLE
Add support "flags" in package sets

### DIFF
--- a/distrobuilder/chroot.go
+++ b/distrobuilder/chroot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lxc/distrobuilder/managers"
 	"github.com/lxc/distrobuilder/shared"
@@ -80,9 +81,9 @@ func managePackages(def *shared.Definition, manager *managers.Manager) error {
 
 	for _, set := range optimizePackageSets(validSets) {
 		if set.Action == "install" {
-			err = manager.Install(set.Packages)
+			err = manager.Install(set.Packages, set.Flags)
 		} else if set.Action == "remove" {
-			err = manager.Remove(set.Packages)
+			err = manager.Remove(set.Packages, set.Flags)
 		}
 		if err != nil {
 			return err
@@ -111,24 +112,28 @@ func optimizePackageSets(sets []shared.DefinitionPackagesSet) []shared.Definitio
 
 	action := sets[0].Action
 	packages := sets[0].Packages
+	flags := sets[0].Flags
 
 	for i := 1; i < len(sets); i++ {
-		if sets[i].Action == sets[i-1].Action {
+		if sets[i].Action == sets[i-1].Action && strings.Join(sets[i].Flags, " ") == strings.Join(sets[i-1].Flags, " ") {
 			packages = append(packages, sets[i].Packages...)
 		} else {
 			newSets = append(newSets, shared.DefinitionPackagesSet{
 				Action:   action,
 				Packages: packages,
+				Flags:    flags,
 			})
 
 			action = sets[i].Action
 			packages = sets[i].Packages
+			flags = sets[i].Flags
 		}
 	}
 
 	newSets = append(newSets, shared.DefinitionPackagesSet{
 		Action:   action,
 		Packages: packages,
+		Flags:    flags,
 	})
 
 	return newSets

--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -158,6 +158,12 @@ packages:
         - default
 
     - packages:
+        - lightdm
+      action: install
+      flags:
+        - --no-install-recommends
+
+    - packages:
         - grub
       action: remove
 

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -15,6 +15,7 @@ packages:
           architectures: <array> # filter
           releases: <array> # filter
           variants: <array> # filter
+          flags: <array> # install/remove flags for just this set
         - ...
     repositories:
         - name: <string>
@@ -75,7 +76,11 @@ This depends on the package manager though and is not supported by all.
 
 A set contains a list of `packages`, an `action`, and optional filters.
 Here, `packages` is a list of packages which are to be installed or removed.
-The value of `action` must be either `install` or `remove`.
+The value of `action` must be either `install` or `remove`. If `flags` is
+specified for a package set, they are appended to the command specific
+flags, along with any global flags, when calling the `install` or `remove`
+command.  For example, you can define a package set that should be installed
+with `--no-install-recommends`.
 
 `repositories` contains a list of additional repositories which are to be added.
 The `type` field is only needed if the package manager supports more than one repository manager.

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -86,24 +86,26 @@ func GetCustom(def shared.DefinitionPackagesCustomManager) *Manager {
 }
 
 // Install installs packages to the rootfs.
-func (m Manager) Install(pkgs []string) error {
+func (m Manager) Install(pkgs, flags []string) error {
 	if len(m.flags.install) == 0 || pkgs == nil || len(pkgs) == 0 {
 		return nil
 	}
 
 	args := append(m.flags.global, m.flags.install...)
+	args = append(args, flags...)
 	args = append(args, pkgs...)
 
 	return shared.RunCommand(m.commands.install, args...)
 }
 
 // Remove removes packages from the rootfs.
-func (m Manager) Remove(pkgs []string) error {
+func (m Manager) Remove(pkgs, flags []string) error {
 	if len(m.flags.remove) == 0 || pkgs == nil || len(pkgs) == 0 {
 		return nil
 	}
 
 	args := append(m.flags.global, m.flags.remove...)
+	args = append(args, flags...)
 	args = append(args, pkgs...)
 
 	return shared.RunCommand(m.commands.remove, args...)

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -48,6 +48,7 @@ type DefinitionPackagesSet struct {
 	Packages         []string `yaml:"packages"`
 	Action           string   `yaml:"action"`
 	Early            bool     `yaml:"early,omitempty"`
+	Flags            []string `yaml:"flags,omitempty"`
 }
 
 // A DefinitionPackagesRepository contains data of a specific repository


### PR DESCRIPTION
Optionally allow setting `flags` (for the `install` and `remove` actions) in package sets.

This can be used in situations where it is desirable to use `--no-install-recommends` when installing certain packages, as shown below.

-------

Example usage:
```
    - packages:
      - lightdm
      action: install
      flags:
        - --no-install-recommends
```
