### PR TITLE
Don't attempt to re-install packages that were installed early

### DIFF
--- a/doc/source.md
+++ b/doc/source.md
@@ -13,7 +13,6 @@ source:
     suite: <string>
     same_as: <boolean>
     skip_verification: <boolean>
-    early_packages: <array>
 ```
 
 The `downloader` field defines a downloader which pulls a rootfs image which will be used as a starting point.
@@ -64,5 +63,6 @@ This can be used if you want to run `debootstrap foo` but `foo` is missing due t
 
 If `skip_verification` is true, the source tarball is not verified.
 
-`early_packages` is a list of packages which is to be installed while the source is being downloaded.
-This is only used by the `debootstrap` downloader.
+If a package set has the `early` flag enabled, that list of packages will be installed
+while the source is being downloaded. (Note that `early` packages are only supported by
+the `debootstrap` downloader.)


### PR DESCRIPTION
If a package set has the `early: true` option set, those packages are installed with the source (when using `debootstrap`). But because the early packages remain in the set of packages, they are attempted to be installed again.

This is a minor cosmetic issue, but not attempting to re-install the early packages makes the install log slightly cleaner.

Also remove references to the old `early_packages` option in the docs.