### PR TITLE
sources/alpine: Fix edge builds

### DIFF
--- a/sources/alpine-http.go
+++ b/sources/alpine-http.go
@@ -103,7 +103,7 @@ func (s *AlpineLinuxHTTP) Run(definition shared.Definition, rootfsDir string) er
 			return err
 		}
 
-		err = shared.RunCommand("sed", "-i", "-e", "s/v[[:digit:]]\\.[[:digit:]]/edge/g", "/etc/apk/repositories")
+		err = shared.RunCommand("sed", "-i", "-e", "s/v[[:digit:]]\\.[[:digit:]]+/edge/g", "/etc/apk/repositories")
 		if err != nil {
 			exitChroot()
 			return err


### PR DESCRIPTION
When building the edge release, the same_as field is required for
downloading the source tarball and fixing the repo URLs.
This commit fixes the regex which is used to alter the apk repo file.
It now includes versions like 3.10 and above.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>