### PR TITLE
sources/alpine: Fix regex

### DIFF
--- a/sources/alpine-http.go
+++ b/sources/alpine-http.go
@@ -103,7 +103,7 @@ func (s *AlpineLinuxHTTP) Run(definition shared.Definition, rootfsDir string) er
 			return err
 		}
 
-		err = shared.RunCommand("sed", "-i", "-e", "s/v[[:digit:]]\\.[[:digit:]]+/edge/g", "/etc/apk/repositories")
+		err = shared.RunCommand("sed", "-i", "-e", "s/v[[:digit:]]\\.[[:digit:]]\\+/edge/g", "/etc/apk/repositories")
 		if err != nil {
 			exitChroot()
 			return err


### PR DESCRIPTION
This fixes the regex which updates the repos for edge releases.

This fixes https://github.com/lxc/lxc-ci/issues/107.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>