### PR TITLE
main: Fix build-lxd for VMs

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -275,6 +275,7 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 
 		if ok {
 			imageTargets |= shared.ImageTargetVM
+			c.definition.Targets.Type = "vm"
 		} else {
 			imageTargets |= shared.ImageTargetContainer
 		}

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -53,10 +53,6 @@ func (c *cmdLXD) commandBuild() *cobra.Command {
 			}
 			defer cleanup()
 
-			if c.flagVM {
-				c.global.definition.Targets.Type = "vm"
-			}
-
 			return c.run(cmd, args, overlayDir)
 		},
 	}


### PR DESCRIPTION
This fixes an issue where the --vm flag would be ignored if running
build-lxd.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>