### PR TITLE
chroot: Don't bind-mount /dev

### DIFF
--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -9,6 +9,7 @@ import (
 	lxd "github.com/lxc/lxd/shared"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/distrobuilder/generators"
 	"github.com/lxc/distrobuilder/image"
@@ -269,6 +270,21 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 		rootfsDir = vmDir
 
 		mounts = []shared.ChrootMount{
+			{
+				Source: vm.getLoopDev(),
+				Target: filepath.Join("/", "dev", filepath.Base(vm.getLoopDev())),
+				Flags:  unix.MS_BIND,
+			},
+			{
+				Source: vm.getRootfsDevFile(),
+				Target: filepath.Join("/", "dev", filepath.Base(vm.getRootfsDevFile())),
+				Flags:  unix.MS_BIND,
+			},
+			{
+				Source: vm.getUEFIDevFile(),
+				Target: filepath.Join("/", "dev", filepath.Base(vm.getUEFIDevFile())),
+				Flags:  unix.MS_BIND,
+			},
 			{
 				Source: vm.getUEFIDevFile(),
 				Target: "/boot/efi",

--- a/distrobuilder/vm.go
+++ b/distrobuilder/vm.go
@@ -38,6 +38,10 @@ func newVM(imageFile, rootfsDir, fs string, size uint64) (*vm, error) {
 	return &vm{imageFile: imageFile, rootfsDir: rootfsDir, rootFS: fs, size: size}, nil
 }
 
+func (v *vm) getLoopDev() string {
+	return v.loopDevice
+}
+
 func (v *vm) getRootfsDevFile() string {
 	if v.loopDevice == "" {
 		return ""


### PR DESCRIPTION
Instead of bind-mounting /dev, it now creates necessary /dev files using
mknod. When creating VMs, it bind-mounts the loop device and its
partitions as well.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>