### PR TITLE
shared: Differentiate between build-dir and others

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -259,15 +259,23 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 	// Unmount everything and exit the chroot
 	defer exitChroot()
 
-	// If we're running build-dir, only process sections which are meant for both
-	// containers and VMs.
-	imageTargets := shared.ImageTargetAll
+	var imageTargets shared.ImageTarget
 
-	// If we call build-lxc or build-lxd, also process container-only sections.
+	// If we're running either build-lxc or build-lxd, include types which are
+	// meant for all.
+	// If we're running build-dir, only process section which DO NOT specify
+	// a types filter.
+	if !isRunningBuildDir {
+		imageTargets = shared.ImageTargetAll
+	}
+
 	switch cmd.CalledAs() {
 	case "build-lxc":
+		// If we're running build-lxc, also process container-only sections.
 		imageTargets |= shared.ImageTargetContainer
 	case "build-lxd":
+		// Include either container-specific or vm-specific sections when
+		// running build-lxd.
 		ok, err := cmd.Flags().GetBool("vm")
 		if err != nil {
 			return err

--- a/distrobuilder/main_build-dir.go
+++ b/distrobuilder/main_build-dir.go
@@ -28,7 +28,7 @@ func (c *cmdBuildDir) command() *cobra.Command {
 					return fmt.Errorf("Unknown generator '%s'", file.Generator)
 				}
 
-				if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetAll) {
+				if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) {
 					continue
 				}
 

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -71,7 +71,7 @@ func (c *cmdLXC) runPack(cmd *cobra.Command, args []string, overlayDir string) e
 	defer exitChroot()
 
 	var manager *managers.Manager
-	imageTargets := shared.ImageTargetContainer
+	imageTargets := shared.ImageTargetAll | shared.ImageTargetContainer
 
 	if c.global.definition.Packages.Manager != "" {
 		manager = managers.Get(c.global.definition.Packages.Manager)

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -121,7 +121,7 @@ func (c *cmdLXD) runPack(cmd *cobra.Command, args []string, overlayDir string) e
 	defer exitChroot()
 
 	var manager *managers.Manager
-	var imageTargets shared.ImageTarget
+	imageTargets := shared.ImageTargetAll
 
 	if c.flagVM {
 		imageTargets = shared.ImageTargetVM

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -594,20 +594,24 @@ func ApplyFilter(filter Filter, release string, architecture string, variant str
 
 	types := filter.GetTypes()
 
+	if acceptedImageTargets == 0 && len(types) == 0 {
+		return true
+	}
+
 	if acceptedImageTargets&ImageTargetAll > 0 {
-		if len(types) == 0 || len(types) == 2 && shared.StringInSlice(targetType, types) {
+		if len(types) == 2 && shared.StringInSlice(targetType, types) {
 			return true
 		}
 	}
 
 	if acceptedImageTargets&ImageTargetContainer > 0 {
-		if targetType == "container" && len(types) == 1 && types[0] == targetType {
+		if targetType == "container" && shared.StringInSlice(targetType, types) {
 			return true
 		}
 	}
 
 	if acceptedImageTargets&ImageTargetVM > 0 {
-		if targetType == "vm" && len(types) == 1 && types[0] == targetType {
+		if targetType == "vm" && shared.StringInSlice(targetType, types) {
 			return true
 		}
 	}


### PR DESCRIPTION
This changes the types filtering behaviour.
When running build-dir, only section with no types filter will be
processed.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>