### PR TITLE
shared/definition: Fix early packages

### DIFF
--- a/shared/definition.go
+++ b/shared/definition.go
@@ -501,7 +501,7 @@ func (d *Definition) GetEarlyPackages(action string) []string {
 	normal := []DefinitionPackagesSet{}
 
 	for _, set := range d.Packages.Sets {
-		if set.Early && set.Action == action && ApplyFilter(&set, d.Image.Release, d.Image.ArchitectureMapped, d.Image.Variant, d.Targets.Type, ImageTargetAll) {
+		if set.Early && set.Action == action && ApplyFilter(&set, d.Image.Release, d.Image.ArchitectureMapped, d.Image.Variant, d.Targets.Type, 0) {
 			early = append(early, set.Packages...)
 		} else {
 			normal = append(normal, set)


### PR DESCRIPTION
Early packages usually don't have a specific target and therefore should
have no value for that.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>