### PR TITLE
main: Fix file generators

### DIFF
--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -122,7 +122,8 @@ func (c *cmdLXC) run(cmd *cobra.Command, args []string, overlayDir string) error
 			return fmt.Errorf("Unknown generator '%s'", file.Generator)
 		}
 
-		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetAll|shared.ImageTargetContainer) {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) &&
+			!shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetAll|shared.ImageTargetContainer) {
 			continue
 		}
 

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -182,7 +182,8 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 	}
 
 	for _, file := range c.global.definition.Files {
-		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, imageTargets) {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) &&
+			!shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, imageTargets) {
 			continue
 		}
 


### PR DESCRIPTION
Entries in the files section should always be considered if they have no
type filter specified.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>