### PR TITLE
main,shared: Fix undefined image target

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -259,14 +259,14 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 	// Unmount everything and exit the chroot
 	defer exitChroot()
 
-	var imageTargets shared.ImageTarget
+	// Always include sections which have no type filter. If running build-dir,
+	// only these sections will be processed.
+	imageTargets := shared.ImageTargetUndefined
 
 	// If we're running either build-lxc or build-lxd, include types which are
 	// meant for all.
-	// If we're running build-dir, only process section which DO NOT specify
-	// a types filter.
 	if !isRunningBuildDir {
-		imageTargets = shared.ImageTargetAll
+		imageTargets |= shared.ImageTargetAll
 	}
 
 	switch cmd.CalledAs() {

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -122,8 +122,7 @@ func (c *cmdLXC) run(cmd *cobra.Command, args []string, overlayDir string) error
 			return fmt.Errorf("Unknown generator '%s'", file.Generator)
 		}
 
-		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) &&
-			!shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetAll|shared.ImageTargetContainer) {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetUndefined|shared.ImageTargetAll|shared.ImageTargetContainer) {
 			continue
 		}
 

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -173,7 +173,7 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 	img := image.NewLXDImage(overlayDir, c.global.targetDir,
 		c.global.flagCacheDir, *c.global.definition)
 
-	imageTargets := shared.ImageTargetAll
+	imageTargets := shared.ImageTargetUndefined | shared.ImageTargetAll
 
 	if c.flagVM {
 		imageTargets |= shared.ImageTargetVM
@@ -182,8 +182,7 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 	}
 
 	for _, file := range c.global.definition.Files {
-		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) &&
-			!shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, imageTargets) {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, imageTargets) {
 			continue
 		}
 

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -24,6 +24,9 @@ const (
 
 	// ImageTargetVM is used for VM targets.
 	ImageTargetVM ImageTarget = 1 << 2
+
+	// ImageTargetUndefined is used when no type has been specified.
+	ImageTargetUndefined ImageTarget = 1 << 3
 )
 
 // Filter represents a filter.
@@ -594,7 +597,7 @@ func ApplyFilter(filter Filter, release string, architecture string, variant str
 
 	types := filter.GetTypes()
 
-	if acceptedImageTargets == 0 && len(types) == 0 {
+	if (acceptedImageTargets == 0 || acceptedImageTargets&ImageTargetUndefined > 0) && len(types) == 0 {
 		return true
 	}
 

--- a/shared/definition_test.go
+++ b/shared/definition_test.go
@@ -526,6 +526,8 @@ func TestApplyFilter(t *testing.T) {
 	// Targets
 	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
 	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", 0))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetUndefined))
 	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetVM))
 	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetAll|ImageTargetVM))
 	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer|ImageTargetVM))


### PR DESCRIPTION
This fixes build-{lxc,lxd} where it would fail to process sections with
no defined type filter.

This fixes #304.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>