### PR TITLE
shared/util: preserve xattrs in Pack/PackUpdate

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -233,7 +233,7 @@ func CreateGPGKeyring(keyserver string, keys []string) (string, error) {
 
 // Pack creates an uncompressed tarball.
 func Pack(filename, compression, path string, args ...string) error {
-	err := RunCommand("tar", append([]string{"-cf", filename, "-C", path}, args...)...)
+	err := RunCommand("tar", append([]string{"--xattrs", "-cf", filename, "-C", path}, args...)...)
 	if err != nil {
 		// Clean up incomplete tarball
 		os.Remove(filename)
@@ -245,7 +245,7 @@ func Pack(filename, compression, path string, args ...string) error {
 
 // PackUpdate updates an existing tarball.
 func PackUpdate(filename, compression, path string, args ...string) error {
-	err := RunCommand("tar", append([]string{"-uf", filename, "-C", path}, args...)...)
+	err := RunCommand("tar", append([]string{"--xattrs", "-uf", filename, "-C", path}, args...)...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
tar does not preserve xattrs by default, so update Pack and PackUpdate
to use the --xattrs flag. This avoids dropping the security.capability
xattr, which is used for binaries such as ping.

Downstream bug: https://crbug.com/1093811

Signed-off-by: Stephen Barber <smbarber@chromium.org>