### PR TITLE
generators: Add copy generator

### DIFF
--- a/doc/examples/ubuntu.yaml
+++ b/doc/examples/ubuntu.yaml
@@ -73,6 +73,10 @@ files:
 - path: /etc/machine-id
   generator: dump
 
+- path: /etc/user/profile
+  generator: copy
+  source: /etc/profile
+
 - path: /var/lib/dbus/machine-id
   generator: remove
 

--- a/doc/generators.md
+++ b/doc/generators.md
@@ -58,6 +58,24 @@ If provided, it will set the `mode` (octal format), `gid` (integer) and/or `uid`
 If `pongo` is true, the content will be processed using pongo2, and the context will be set appropriately (`{{ lxc.<variable> }}` or `{{ lxd.<variable> }}`).
 See  [targets](targets.md).
 
+## copy
+
+The `copy` generator copies the file(s) from `source` to the destination `path`.
+`path` can be left empty and in that case the data will be placed in the same `source` path but inside the container.
+If provided, the destination `path` will set the `mode` (octal format), `gid` (integer) and/or `uid` (integer).
+Copying will be done according to the following rules:
+
+* If `source` is a directory, the entire contents of the directory are copied. Only symlinks and regular files are supported.
+	- Note 1: The directory itself is not copied, just its contents.
+	- Note 2: For files copied, only regular unix permissions are kept.
+* If `source` is a symlink or a regular file, it is copied individually along with its metadata.
+In this case, if `path` ends with a trailing slash `/`, it will be considered a directory and the contents of `source` will be written at `path`/base(`source`).
+* If `path` does not end with a trailing slash, it will be considered a regular file and the contents of `source` will be written at `path`.
+* If `path` does not exist, it is created along with all missing directories in its path.
+* Multiple `source` resources can be specified using golang `filepath.Match` regexps.
+For simplicity they are only allowed in the basename and not in the directory hierarchy.
+If more than one match is found, `path` will be automatically interpreted as a directory.
+
 ## hostname
 
 For LXC images, the hostname generator writes the LXC specific string `LXC_NAME` to the hostname file set in `path`.

--- a/generators/copy.go
+++ b/generators/copy.go
@@ -1,0 +1,173 @@
+package generators
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/lxc/distrobuilder/image"
+	"github.com/lxc/distrobuilder/shared"
+	lxd "github.com/lxc/lxd/shared"
+)
+
+// CopyGenerator represents the Copy generator.
+type CopyGenerator struct{}
+
+// RunLXC copies a file to the container.
+func (g CopyGenerator) RunLXC(cacheDir, sourceDir string, img *image.LXCImage,
+	target shared.DefinitionTargetLXC, defFile shared.DefinitionFile) error {
+	return g.Run(cacheDir, sourceDir, defFile)
+}
+
+// RunLXD copies a file to the container.
+func (g CopyGenerator) RunLXD(cacheDir, sourceDir string, img *image.LXDImage,
+	target shared.DefinitionTargetLXD, defFile shared.DefinitionFile) error {
+	return g.Run(cacheDir, sourceDir, defFile)
+}
+
+// Run copies a file to the container.
+func (g CopyGenerator) Run(cacheDir, sourceDir string,
+	defFile shared.DefinitionFile) error {
+	// First check if the input is a file or a directory.
+	// Then check whether the destination finishes in a "/" or not
+	// Afterwards, the rules for copying can be applied. See doc/generators.md
+
+	// Set the name of the destination file to the input file
+	// relative to the root if destination file is missing
+	var destPath, srcPath string
+	var files []string
+	srcPath = defFile.Source
+	destPath = filepath.Join(sourceDir, defFile.Source)
+	if defFile.Path != "" {
+		destPath = filepath.Join(sourceDir, defFile.Path)
+	}
+
+	dirFiles, err := ioutil.ReadDir(filepath.Dir(srcPath))
+	if err != nil {
+		return err
+	}
+	for _, f := range dirFiles {
+		match, err := filepath.Match(srcPath, filepath.Join(filepath.Dir(srcPath), f.Name()))
+		if err != nil {
+			return err
+		}
+		if match {
+			files = append(files, filepath.Join(filepath.Dir(srcPath), f.Name()))
+		}
+	}
+
+	switch len(files) {
+	case 0:
+		// Look for the literal file
+		_, err = os.Stat(srcPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = fmt.Errorf("File '%s' doesn't exist", srcPath)
+			}
+			return err
+		}
+		err = copy(srcPath, destPath, defFile)
+	case 1:
+		err = copy(srcPath, destPath, defFile)
+	default:
+		// Make sure that we are copying to a directory
+		defFile.Path = defFile.Path + "/"
+		for _, f := range files {
+			err = copy(f, destPath, defFile)
+			if err != nil {
+				break
+			}
+		}
+	}
+	return err
+}
+
+func copy(srcPath, destPath string, defFile shared.DefinitionFile) error {
+	in, err := os.Stat(srcPath)
+	if err != nil {
+		return err
+	}
+
+	switch in.Mode() & os.ModeType {
+	// Regular file
+	case 0, os.ModeSymlink:
+		if strings.HasSuffix(defFile.Path, "/") {
+			destPath = filepath.Join(destPath, filepath.Base(srcPath))
+		}
+		err := copyFile(srcPath, destPath, defFile)
+		if err != nil {
+			return err
+		}
+
+	case os.ModeDir:
+		err := copyDir(srcPath, destPath, defFile)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("File type of %s not supported", srcPath)
+	}
+
+	return nil
+}
+
+func copyDir(srcPath, destPath string, defFile shared.DefinitionFile) error {
+	err := filepath.Walk(srcPath, func(src string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(srcPath, src)
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(destPath, rel)
+		if err != nil {
+			return err
+		}
+
+		switch fi.Mode() & os.ModeType {
+		case 0, os.ModeSymlink:
+			err = copyFile(src, dest, defFile)
+			if err != nil {
+				return err
+			}
+		case os.ModeDir:
+			err := os.MkdirAll(dest, os.ModePerm)
+			if err != nil {
+				return err
+			}
+		default:
+			fmt.Printf("File type of %s not supported, skipping", src)
+		}
+		return nil
+	})
+
+	return err
+}
+
+func copyFile(src, dest string, defFile shared.DefinitionFile) error {
+	// Let's make sure that we can create the file
+	dir := filepath.Dir(dest)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, os.ModePerm)
+	}
+	if err != nil {
+		return err
+	}
+
+	err = lxd.FileCopy(src, dest)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Open(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	return updateFileAccess(out, defFile)
+}

--- a/generators/copy_test.go
+++ b/generators/copy_test.go
@@ -1,0 +1,166 @@
+package generators
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lxc/distrobuilder/shared"
+)
+
+func TestCopyGeneratorRun(t *testing.T) {
+	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	rootfsDir := filepath.Join(cacheDir, "rootfs")
+
+	setup(t, cacheDir)
+	defer teardown(cacheDir)
+
+	generator := Get("copy")
+	require.Equal(t, CopyGenerator{}, generator)
+
+	defer os.RemoveAll("copy_test")
+
+	err := os.Mkdir("copy_test", os.ModePerm)
+	require.Nil(t, err)
+	src1, err := os.Create(filepath.Join("copy_test", "src1"))
+	require.Nil(t, err)
+	defer src1.Close()
+	_, err = src1.WriteString("src1\n")
+	require.Nil(t, err)
+	src2, err := os.Create(filepath.Join("copy_test", "src2"))
+	require.Nil(t, err)
+	defer src2.Close()
+	_, err = src2.WriteString("src2\n")
+	require.Nil(t, err)
+	err = os.Symlink("src1", filepath.Join("copy_test", "srcLink"))
+	require.Nil(t, err)
+
+	// <src> is a directory -> contents copied
+	err = generator.Run(cacheDir, rootfsDir, shared.DefinitionFile{
+		Source: "copy_test",
+		Path:   "copy_test_dir",
+	})
+	require.Nil(t, err)
+
+	require.DirExists(t, filepath.Join(rootfsDir, "copy_test_dir"))
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test_dir", "src1"))
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test_dir", "src2"))
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test_dir", "srcLink"))
+
+	var destBuffer, srcBuffer bytes.Buffer
+	dest, err := os.Open(filepath.Join(rootfsDir, "copy_test_dir", "src1"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	io.Copy(&destBuffer, dest)
+	_, err = src1.Seek(0, 0)
+	require.Nil(t, err)
+	io.Copy(&srcBuffer, src1)
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+
+	dest, err = os.Open(filepath.Join(rootfsDir, "copy_test_dir", "src2"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	destBuffer.Reset()
+	io.Copy(&destBuffer, dest)
+	_, err = src2.Seek(0, 0)
+	require.Nil(t, err)
+	srcBuffer.Reset()
+	io.Copy(&srcBuffer, src2)
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+
+	link, err := os.Readlink(filepath.Join(rootfsDir, "copy_test_dir", "srcLink"))
+	require.Nil(t, err)
+	require.Equal(t, "src1", link)
+
+	// <src> as wildcard
+	_, err = src1.Seek(0, 0)
+	_, err = src2.Seek(0, 0)
+	err = generator.Run(cacheDir, rootfsDir, shared.DefinitionFile{
+		Source: "copy_test/src*",
+		Path:   "copy_test_wildcard",
+	})
+	require.Nil(t, err)
+
+	require.DirExists(t, filepath.Join(rootfsDir, "copy_test_wildcard"))
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test_wildcard", "src1"))
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test_wildcard", "src2"))
+
+	dest, err = os.Open(filepath.Join(rootfsDir, "copy_test_wildcard", "src1"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	destBuffer.Reset()
+	io.Copy(&destBuffer, dest)
+	_, err = src1.Seek(0, 0)
+	require.Nil(t, err)
+	srcBuffer.Reset()
+	io.Copy(&srcBuffer, src1)
+
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+
+	dest, err = os.Open(filepath.Join(rootfsDir, "copy_test_wildcard", "src2"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	destBuffer.Reset()
+	io.Copy(&destBuffer, dest)
+	_, err = src2.Seek(0, 0)
+	require.Nil(t, err)
+	srcBuffer.Reset()
+	io.Copy(&srcBuffer, src2)
+
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+
+	// <src> is a file -> file copied to <dest>
+	_, err = src1.Seek(0, 0)
+	err = generator.Run(cacheDir, rootfsDir, shared.DefinitionFile{
+		Source: "copy_test/src1",
+	})
+	require.Nil(t, err)
+
+	require.FileExists(t, filepath.Join(rootfsDir, "copy_test", "src1"))
+
+	dest, err = os.Open(filepath.Join(rootfsDir, "copy_test", "src1"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	destBuffer.Reset()
+	io.Copy(&destBuffer, dest)
+	_, err = src1.Seek(0, 0)
+	require.Nil(t, err)
+	srcBuffer.Reset()
+	io.Copy(&srcBuffer, src1)
+
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+
+	// <src> is a file -> file copied to <dest>/
+	_, err = src1.Seek(0, 0)
+	require.Nil(t, err)
+	err = generator.Run(cacheDir, rootfsDir, shared.DefinitionFile{
+		Source: "copy_test/src1",
+		Path:   "/hello/world/",
+	})
+	require.Nil(t, err)
+
+	require.DirExists(t, filepath.Join(rootfsDir, "hello", "world"))
+	require.FileExists(t, filepath.Join(rootfsDir, "hello", "world", "src1"))
+
+	dest, err = os.Open(filepath.Join(rootfsDir, "hello", "world", "src1"))
+	require.Nil(t, err)
+	defer dest.Close()
+
+	destBuffer.Reset()
+	io.Copy(&destBuffer, dest)
+	_, err = src1.Seek(0, 0)
+	require.Nil(t, err)
+	srcBuffer.Reset()
+	io.Copy(&srcBuffer, src1)
+
+	require.Equal(t, destBuffer.String(), srcBuffer.String())
+}

--- a/generators/generators.go
+++ b/generators/generators.go
@@ -28,6 +28,8 @@ func Get(generator string) Generator {
 		return RemoveGenerator{}
 	case "dump":
 		return DumpGenerator{}
+	case "copy":
+		return CopyGenerator{}
 	case "template":
 		return TemplateGenerator{}
 	case "upstart-tty":

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -184,6 +184,7 @@ type DefinitionFile struct {
 	GID              string                 `yaml:"gid,omitempty"`
 	UID              string                 `yaml:"uid,omitempty"`
 	Pongo            bool                   `yaml:"pongo,omitempty"`
+	Source           string                 `yaml:"source,omitempty"`
 }
 
 // A DefinitionFileTemplate represents the settings used by generators
@@ -391,6 +392,7 @@ func (d *Definition) Validate() error {
 
 	validGenerators := []string{
 		"dump",
+		"copy",
 		"template",
 		"hostname",
 		"hosts",


### PR DESCRIPTION
Closes #110

Copy any file from the host to the container using "destination".
Logic is very similar to that one from Docker.

First check if the input is a file or a directory.
Then check whether the destination finishes in a "/" or not
Afterwards, the rules for copying can be applied
Rules for copying:
 - If <src> is a directory, the entire contents of the directory
are copied. Only symlinks and regular files are supported.
Note 1: The directory itself is not copied, just its contents.
Note 2: For files copied, only regular unix permissions are kept
 - If <src> is any other kind of file, it is copied individually
along with its metadata. In this case, if <dest> ends with a trailing
slash /, it will be considered a directory and the contents of <src>
will be written at <dest>/base(<src>).
 - If <dest> does not end with a trailing slash, it will be considered
a regular file and the contents of <src> will be written at <dest>.
- If <dest> doesn’t exist, it is created along with all missing
directories in its path.
 - Multiple <src> resources can be specified using golang regexps.
For simplicity they are only allowed in the basename and not in
the directory hierarchy. If more than one match is found, <dest>
will be automatically interpreted as a directory

Signed-off-by: Pablo Correa Gómez <ablocorrea@hotmail.com>

Sorry it took so long to resubmit this PR. Hopefully it looks much better now and I'm able to be more responsive on requests.