### PR TITLE
Added missing definitions in generators hosts, hostname

### DIFF
--- a/generators/hostname.go
+++ b/generators/hostname.go
@@ -70,11 +70,16 @@ func (g HostnameGenerator) RunLXD(cacheDir, sourceDir string, img *image.LXDImag
 
 	// Add to LXD templates
 	img.Metadata.Templates[defFile.Path] = &api.ImageMetadataTemplate{
-		Template: "hostname.tpl",
-		When: []string{
+		Template:   "hostname.tpl",
+		Properties: defFile.Template.Properties,
+		When:       defFile.Template.When,
+	}
+
+	if len(defFile.Template.When) == 0 {
+		img.Metadata.Templates[defFile.Path].When = []string{
 			"create",
 			"copy",
-		},
+		}
 	}
 
 	return err

--- a/generators/hosts.go
+++ b/generators/hosts.go
@@ -92,11 +92,16 @@ func (g HostsGenerator) RunLXD(cacheDir, sourceDir string, img *image.LXDImage,
 	}
 
 	img.Metadata.Templates[defFile.Path] = &api.ImageMetadataTemplate{
-		Template: "hosts.tpl",
-		When: []string{
+		Template:   "hosts.tpl",
+		Properties: defFile.Template.Properties,
+		When:       defFile.Template.When,
+	}
+
+	if len(defFile.Template.When) == 0 {
+		img.Metadata.Templates[defFile.Path].When = []string{
 			"create",
 			"copy",
-		},
+		}
 	}
 
 	return err


### PR DESCRIPTION
Signed-off-by: Get OpenDroplet <getopendroplet@gmail.com>

Was skipped definition from config file.