### PR TITLE
sources/docker: Permit to use private docker registry with credentials

### DIFF
--- a/sources/docker.go
+++ b/sources/docker.go
@@ -26,7 +26,9 @@ func (d *DockerHTTP) Run(definition shared.Definition, rootfsDir string) error {
 
 	// If DOCKER_REGISTRY_BASE is not set it's used default https://registry-1.docker.io
 	return dcapi.DownloadAndUnpackImage(definition.Source.URL, absRootfsDir, &dcapi.DownloadOpts{
-		RegistryBase: os.Getenv("DOCKER_REGISTRY_BASE"),
-		KeepLayers:   false,
+		RegistryBase:     os.Getenv("DOCKER_REGISTRY_BASE"),
+		RegistryUsername: os.Getenv("DOCKER_REGISTRY_BASE_USER"),
+		RegistryPassword: os.Getenv("DOCKER_REGISTRY_BASE_PASS"),
+		KeepLayers:       false,
 	})
 }


### PR DESCRIPTION
This permits to creation LXD image from a docker image pulled by a private docker registry with a username and a password.
Require master upstream of the docker-companion project.