### PR TITLE
Add ability to make Openwrt 21.02 images

### DIFF
--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -85,8 +85,13 @@ func (s *openwrt) Run() error {
 	} else {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":
-			fname = fmt.Sprintf("openwrt-%s%s-generic-rootfs.tar.gz", releaseInFilename,
-				strings.Replace(architecturePath, "/", "-", 1))
+			if strings.HasPrefix(release, "21.02") {
+				fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
+					strings.Replace(architecturePath, "/", "-", 1))
+			} else {
+				fname = fmt.Sprintf("openwrt-%s%s-generic-rootfs.tar.gz", releaseInFilename,
+					strings.Replace(architecturePath, "/", "-", 1))
+			}
 		case "armv7l":
 			fallthrough
 		case "aarch64":


### PR DESCRIPTION
Signed-off-by: Benjamin McGuire <benjamin@reelworks.net>

Due to changes in the filename, the Release Candidates are using the same naming for the rootfs image as the snapshots.

Tested on rc1 - rc3
