### PR TITLE
Avoid systemd generator to break systemd-networkd connections

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -562,6 +562,7 @@ fix_nm_link_state() {
 [Unit]
 Description=Turn off network device
 Before=NetworkManager.service
+Before=systemd-networkd.service
 
 [Service]
 ExecStart=-${ip_path} link set $1 down


### PR DESCRIPTION
With `/run/systemd/system/network-device-down.service` in place and
NetworkManager installed, systemd-networkd brings up the networking and
assings an IP address, but then shortly after the inteface is brought
down by this service, breaking the network connection.

Add a `Before=systemd-networkd.service` dependency, to bring down the
interface before systemd-networkd is started and let it do it's thing
afterwards.

Fixes [LP: #1931088](https://bugs.launchpad.net/ubuntu/+source/lxd/+bug/1931088)
Related to https://github.com/lxc/distrobuilder/commit/aea15277f86a4a4bd4e3afcbc81105e4c6a7ca16

Signed-off-by: Lukas Märdian <slyon@ubuntu.com>