### PR TITLE
sources/plamolinux: Fix a process related to pkgtools8

### DIFF
--- a/sources/plamolinux-http.go
+++ b/sources/plamolinux-http.go
@@ -113,7 +113,7 @@ do
 done
 
 # generate symblic link to static-zstd
-( cd "${PKG_DIR}/sbin" && ln -sf zstd-* zstd )
+( cd "${PKG_DIR}/sbin/installer" && ln -sf zstd-* zstd )
 
 # Don't call ldconfig
 sed -i "/ldconfig/!s@/sbin@${PKG_DIR}&@g" ${PKG_DIR}/sbin/installpkg*


### PR DESCRIPTION
symlink to zstd-static are now created properly.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>