### PR TITLE
sources/plamolinux: more fix related to pkgtools8

### DIFF
--- a/sources/plamolinux-http.go
+++ b/sources/plamolinux-http.go
@@ -93,7 +93,7 @@ PKG_DIR="%s"
 ROOTFS_DIR="%s"
 
 # Environment
-export PATH="${PKG_DIR}/sbin:${PATH}"
+export PATH="${PATH}:${PKG_DIR}/sbin:${PKG_DIR}/sbin/installer"
 export LC_ALL="C"
 export LANG="C"
 


### PR DESCRIPTION
The path to the statically linked zstd command was not set, so I set.

In addition, Changed to prioritize host environment commands over
commands included in pkgtools8.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>