### PR TITLE
shared/util: Drop -X for rsync

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -458,7 +458,7 @@ func getChecksum(fname string, hashLen int, r io.Reader) []string {
 
 // RsyncLocal copies src to dest using rsync.
 func RsyncLocal(src string, dest string) error {
-	err := RunCommand("rsync", "-aHASX", "--devices", src, dest)
+	err := RunCommand("rsync", "-aHAS", "--devices", src, dest)
 	if err != nil {
 		return errors.WithMessagef(err, "Failed to copy %q to %q", src, dest)
 	}


### PR DESCRIPTION
At least one distro doesn't build using the -X (--xattrs) option. We
should therefore drop it.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
