### PR TITLE
sources/debootstrap: Handle merged /usr

### DIFF
--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -20,6 +20,16 @@ type debootstrap struct {
 func (s *debootstrap) Run() error {
 	var args []string
 
+	distro := strings.ToLower(s.definition.Image.Distribution)
+	release := strings.ToLower(s.definition.Image.Release)
+
+	// Enable merged /usr by default, and disable it for certain distros/releases
+	if distro == "ubuntu" && lxd.StringInSlice(release, []string{"xenial", "bionic"}) || distro == "mint" && lxd.StringInSlice(release, []string{"tara", "tessa", "tina", "tricia", "ulyana"}) || distro == "devuan" {
+		args = append(args, "--no-merged-usr")
+	} else {
+		args = append(args, "--merged-usr")
+	}
+
 	os.RemoveAll(s.rootfsDir)
 
 	if s.definition.Source.Variant != "" {


### PR DESCRIPTION
This enables merged /usr by default, and disables it for certain
distros/releases.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
