### PR TITLE
main: remove NoNewPrivileges=no from systemd-generator

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -640,7 +640,6 @@ fix_systemd_override_unit() {
 		[ "${systemd_version}" -ge 247 ] && echo "ProtectProc=default";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectControlGroups=no";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectKernelTunables=no";
-		[ "${systemd_version}" -ge 239 ] && echo "NoNewPrivileges=no";
 		[ "${systemd_version}" -ge 249 ] && echo "LoadCredential=";
 
 		# Additional settings for privileged containers


### PR DESCRIPTION
PR #495 mentions that NoNewPrivileges needed to be deactivated
to fix systemd failures on alt/Sisyphus and Arch Linux. However,
on recent kernels (with fixes for [1] and [2]), NNP should work
properly inside containers.

1: https://bugs.launchpad.net/bugs/1839037
2: https://bugs.launchpad.net/bugs/1844186

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>