### PR TITLE
Revert "main: remove NoNewPrivileges=no from systemd-generator"

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -640,6 +640,7 @@ fix_systemd_override_unit() {
 		[ "${systemd_version}" -ge 247 ] && echo "ProtectProc=default";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectControlGroups=no";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectKernelTunables=no";
+		[ "${systemd_version}" -ge 239 ] && echo "NoNewPrivileges=no";
 		[ "${systemd_version}" -ge 249 ] && echo "LoadCredential=";
 
 		# Additional settings for privileged containers


### PR DESCRIPTION
This reverts commit 3e6e3b89177d70ae4b0919d792b4b3596465609b.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
