### PR TITLE
github: Bump Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         go:
           - 1.13.x
-          - 1.14.x
-          - 1.15.x
+          - 1.16.x
+          - 1.17.x
         os:
           - ubuntu-18.04
           - ubuntu-20.04


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>