### PR TITLE
generators/cloud-init: Fix network-config

### DIFF
--- a/generators/cloud-init.go
+++ b/generators/cloud-init.go
@@ -143,13 +143,7 @@ config:
 {{- config_get("user.network-config", "") -}}
 {%- endif -%}
 {%- else -%}
-version: 1
-config:
-  - type: physical
-    name: {% if instance.type == "virtual-machine" %}enp5s0{% else %}eth0{% endif %}
-    subnets:
-      - type: dhcp
-        control: auto
+{{- config_get("cloud-init.network-config", "") -}}
 {%- endif %}
 `
 	default:

--- a/generators/cloud-init_test.go
+++ b/generators/cloud-init_test.go
@@ -139,13 +139,7 @@ config:
 {{- config_get("user.network-config", "") -}}
 {%- endif -%}
 {%- else -%}
-version: 1
-config:
-  - type: physical
-    name: {% if instance.type == "virtual-machine" %}enp5s0{% else %}eth0{% endif %}
-    subnets:
-      - type: dhcp
-        control: auto
+{{- config_get("cloud-init.network-config", "") -}}
 {%- endif %}
 `,
 			false,


### PR DESCRIPTION
This fixes a bug where cloud-init.network-config wouldn't be used if it
was set.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
