### PR TITLE
systemd: Add override for ProcSubset

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -640,6 +640,7 @@ fix_systemd_override_unit() {
 	mkdir -p "${dropin_dir}"
 	{
 		echo "[Service]";
+		[ "${systemd_version}" -ge 247 ] && echo "ProcSubset=all";
 		[ "${systemd_version}" -ge 247 ] && echo "ProtectProc=default";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectControlGroups=no";
 		[ "${systemd_version}" -ge 232 ] && echo "ProtectKernelTunables=no";


### PR DESCRIPTION
This is related to:

 https://github.com/lxc/lxc/issues/4052
 https://discuss.linuxcontainers.org/t/hardened-service-fails-to-start/13118

ProcSubset requires the subset= option on procfs and so requires a
dedicated proc mount which isn't allowed in our containers outside of
/proc itself. As a result, this one should be overriden.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>