### PR TITLE
Remove a handful of NetworkManager hacks

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -779,3 +779,19 @@ fi
 	os.MkdirAll("/etc/systemd/system-generators", 0755)
 	ioutil.WriteFile("/etc/systemd/system-generators/lxc", []byte(content), 0755)
 }
+
+// addVethUdevRule creates an udev rule that makes eth0 work with NetworkManager
+func addVethUdevRule() {
+	content := `
+# This file was created by distrobuilder.
+#
+# Its purpose is to convince NetworkManager to treat the eth0 veth
+# interface like a regular Ethernet. NetworkManager ordinarily doesn't
+# like to manage the veth interfaces, becaue they are typically configured
+# by container management tooling for specialized purposes.
+
+ACTION=="add|change|move", ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="eth[0-9]*", ENV{NM_UNMANAGED}="0"
+`
+	os.MkdirAll("/etc/udev/rules.d", 0755)
+	ioutil.WriteFile("/etc/udev/rules.d/90-lxc-net.rules", []byte(content), 0644)
+}

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -181,6 +181,7 @@ func (c *cmdLXC) run(cmd *cobra.Command, args []string, overlayDir string) error
 	}
 
 	addSystemdGenerator()
+	addVethUdevRule()
 
 	c.global.logger.WithField("trigger", "post-files").Info("Running hooks")
 

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -346,6 +346,7 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 	}
 
 	addSystemdGenerator()
+	addVethUdevRule()
 
 	c.global.logger.WithField("trigger", "post-files").Info("Running hooks")
 


### PR DESCRIPTION
distrobuilder injects some very qeustionable code interacting with NetworkManager.

It seems that it tries to deal with the problem that NetworkManager doesn't like to
manage the eth0 device, because it's a veth -- not a real Ethernet device.

Let's deal with that in what is hopefully a more reasonable way.