### PR TITLE
Revert "lxd-agent: cleaner shutdown sequence"

### DIFF
--- a/generators/lxd-agent.go
+++ b/generators/lxd-agent.go
@@ -74,8 +74,6 @@ Documentation=https://linuxcontainers.org/lxd
 ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
 Before=cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
-After=run-lxd_agent.mount
-Requires=run-lxd_agent.mount
 
 [Service]
 Type=notify


### PR DESCRIPTION
This reverts commit b94de08dc7822730267a403055d4bddf44ac3301.

This fixes regressions of lxd-agent on multiple systemd versions.

Closes https://github.com/lxc/lxc-ci/issues/480

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>