### PR TITLE
vm: Optimise mount options for speed

### DIFF
--- a/distrobuilder/vm.go
+++ b/distrobuilder/vm.go
@@ -271,9 +271,9 @@ func (v *vm) mountRootPartition() error {
 
 	switch v.rootFS {
 	case "btrfs":
-		return shared.RunCommand(v.ctx, nil, nil, "mount", v.getRootfsDevFile(), v.rootfsDir, "-o", "defaults,discard,subvol=/@")
+		return shared.RunCommand(v.ctx, nil, nil, "mount", v.getRootfsDevFile(), v.rootfsDir, "-o", "defaults,discard,nobarrier,commit=300,noatime,subvol=/@")
 	case "ext4":
-		return shared.RunCommand(v.ctx, nil, nil, "mount", v.getRootfsDevFile(), v.rootfsDir, "-o", "discard")
+		return shared.RunCommand(v.ctx, nil, nil, "mount", v.getRootfsDevFile(), v.rootfsDir, "-o", "discard,nobarrier,commit=300,noatime,data=writeback")
 
 	}
 


### PR DESCRIPTION
Enable the following mount options on VM rootfs:
 btrfs: nobarrier,commit=300,noatime
 ext4: nobarrier,commit=300,noatime,data=writeback

Those are normally not recommended but for distrobuilder, it
make sense to have everything copied over as fast as possible
and then persisted properly to disk. We don't care about crash
consistency/fs recovery when building an image.

I used those options when building my own images (before
distrobuilder what a thing) and they allowed faster copying.