### PR TITLE
main: Fix image targets for LXD

### DIFF
--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -163,9 +163,9 @@ func (c *cmdLXD) runPack(cmd *cobra.Command, args []string, overlayDir string) e
 	imageTargets := shared.ImageTargetAll
 
 	if c.flagVM {
-		imageTargets = shared.ImageTargetVM
+		imageTargets |= shared.ImageTargetVM
 	} else {
-		imageTargets = shared.ImageTargetContainer
+		imageTargets |= shared.ImageTargetContainer
 	}
 
 	manager, err := managers.Load(c.global.ctx, c.global.definition.Packages.Manager, c.global.logger, *c.global.definition)


### PR DESCRIPTION
This fixes an issue where the image target would ignore
`ImageTargetAll` when building LXD images.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
