### PR TITLE
source: Return error correctly

### DIFF
--- a/sources/funtoo-http.go
+++ b/sources/funtoo-http.go
@@ -63,7 +63,7 @@ func (s *funtoo) Run() error {
 			return nil
 		}, 3)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		if resp.StatusCode == http.StatusNotFound {

--- a/sources/opensuse-http.go
+++ b/sources/opensuse-http.go
@@ -50,7 +50,7 @@ func (s *opensuse) Run() error {
 		return nil
 	}, 3)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	baseURL, fname = path.Split(resp.Request.URL.String())

--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -110,7 +110,7 @@ func (s *openwrt) Run() error {
 		return nil
 	}, 3)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Use fallback image "generic"


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
