### PR TITLE
shared/version: Bump version to 2.1

### DIFF
--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version contains the distrobuilder version number
-var Version = "2.0"
+var Version = "2.1"


### PR DESCRIPTION
Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
