### PR TITLE
main: export LC_ALL=C

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -548,6 +548,9 @@ func addSystemdGenerator() {
 # NOTE: systemctl is not available for systemd-generators
 set -eu
 
+# disable localisation (faster grep)
+export LC_ALL=C
+
 ## Helper functions
 # is_lxc_container succeeds if we're running inside a LXC container
 is_lxc_container() {


### PR DESCRIPTION
We can get a small speed boost by using the C locale since we are
handling ASCII only anyway.

This saves between 1 and 3 million cycles in my `perf stat` tests
out of 16 to 36 million cycles.