### PR TITLE
image/lxd: stop using qcow2 compat=0.10 (aka qcow2-v2)

### DIFF
--- a/image/lxd.go
+++ b/image/lxd.go
@@ -84,7 +84,7 @@ func (l *LXDImage) Build(unified bool, compression string, vm bool) (string, str
 
 	if vm {
 		// Create compressed qcow2 image.
-		err = shared.RunCommand(l.ctx, nil, nil, "qemu-img", "convert", "-c", "-O", "qcow2", "-o", "compat=0.10",
+		err = shared.RunCommand(l.ctx, nil, nil, "qemu-img", "convert", "-c", "-O", "qcow2",
 			rawImage,
 			qcowImage)
 		if err != nil {


### PR DESCRIPTION
QEMU uses compat=1.1 (aka qcow2-v3) by default since version 1.7 and has support for it since version 1.1.

Apparently, recent RHEL QEMU warn when using compat=0.10 images (https://bugzilla.redhat.com/show_bug.cgi?id=1951814)