### PR TITLE
doc/examples: Fix typos in examples

### DIFF
--- a/doc/examples/sabayon.yaml
+++ b/doc/examples/sabayon.yaml
@@ -1,6 +1,6 @@
 image:
   distribution: sabayon
-  decription: Sabayon Builder
+  description: Sabayon Builder
   expiry: 30d
   variant: builder
   architecture: amd64
@@ -21,7 +21,7 @@ environment:
 
 targets:
   lxc:
-    create-message: |
+    create_message: |
       You just created a Sabayon container (arch={{ image.architecture }})
 
     config:

--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -3,7 +3,7 @@
 image:
   description: |-
     here goes the image description
-  distrobution: distro
+  distribution: distro
   release: release
   architecture: x86_64
   expiry: 30d
@@ -24,7 +24,7 @@ source:
 
 targets:
   lxc:
-    create-message: |-
+    create_message: |-
       You just created an {{ image.description }} container.
 
       To enable SSH, run: apt install openssh-server
@@ -112,7 +112,7 @@ files:
 
 packages:
   manager: apt
-  custom-manager:
+  custom_manager:
     clean:
       cmd: mgr
       flags:
@@ -220,4 +220,5 @@ mappings:
 environment:
   clear_defaults: true
   variables:
-    - FOO: bar
+    - key: FOO
+      value: bar

--- a/doc/examples/ubuntu.yaml
+++ b/doc/examples/ubuntu.yaml
@@ -17,7 +17,7 @@ source:
 
 targets:
   lxc:
-    create-message: |-
+    create_message: |-
       You just created an {{ image.description }} container.
 
       To enable SSH, run: apt install openssh-server


### PR DESCRIPTION
Closes #639.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
