### PR TITLE
Fixes for Rocky Linux 9

### DIFF
--- a/sources/rhel-common.go
+++ b/sources/rhel-common.go
@@ -86,16 +86,18 @@ func (c *commonRHEL) unpackISO(filePath, rootfsDir string, scriptRunner func(str
 		repodataDir = filepath.Join(isoDir, "BaseOS", "repodata")
 	}
 
-	entries, err := os.ReadDir(packagesDir)
-	if err != nil {
-		return fmt.Errorf("Failed reading directory %q: %w", packagesDir, err)
-	}
+	if lxd.PathExists(packagesDir) {
+		entries, err := os.ReadDir(packagesDir)
+		if err != nil {
+			return fmt.Errorf("Failed reading directory %q: %w", packagesDir, err)
+		}
 
-	// If the BaseOS package dir is empty, try a different one, and also change the repodata directory.
-	// This is the case for Rocky Linux 9.
-	if len(entries) == 0 {
-		packagesDir = filepath.Join(isoDir, c.definition.Source.Variant, "Packages")
-		repodataDir = filepath.Join(isoDir, c.definition.Source.Variant, "repodata")
+		// If the BaseOS package dir is empty, try a different one, and also change the repodata directory.
+		// This is the case for Rocky Linux 9.
+		if len(entries) == 0 {
+			packagesDir = filepath.Join(isoDir, c.definition.Source.Variant, "Packages")
+			repodataDir = filepath.Join(isoDir, c.definition.Source.Variant, "repodata")
+		}
 	}
 
 	if lxd.PathExists(packagesDir) && lxd.PathExists(repodataDir) {

--- a/sources/rocky-http.go
+++ b/sources/rocky-http.go
@@ -145,7 +145,8 @@ EOF
 else
 	if ! [ -f /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial ]; then
 		mkdir -p /etc/pki/rpm-gpg
-		cat <<- "EOF" > /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
+		if [ "${RELEASE}" -eq 8 ]; then
+			cat <<- "EOF" > /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v2.0.22 (GNU/Linux)
 mQINBGAofzYBEAC6yS1azw6f3wmaVd//3aSy6O2c9+jeetulRQvg2LvhRRS1eNqp
@@ -176,11 +177,46 @@ JmeWf4VZyebm+gc50szsg6Ut2yT8hw==
 =AiP8
 -----END PGP PUBLIC KEY BLOCK-----
 EOF
+		else
+			cat <<- "EOF" > /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: resf.keykeeper.v1
+Comment: Keykeeper
+
+xsFNBGJ5RksBEADF/Lzssm7uryV6+VHAgL36klyCVcHwvx9Bk853LBOuHVEZWsme
+kbJF3fQG7i7gfCKGuV5XW15xINToe4fBThZteGJziboSZRpkEQ2z3lYcbg34X7+d
+co833lkBNgz1v6QO7PmAdY/x76Q6Hx0J9yiJWd+4j+vRi4hbWuh64vUtTd7rPwk8
+0y3g4oK1YT0NR0Xm/QUO9vWmkSTVflQ6y82HhHIUrG+1vQnSOrWaC0O1lqUI3Nuo
+b6jTARCmbaPsi+XVQnBbsnPPq6Tblwc+NYJSqj5d9nT0uEXT7Zovj4Je5oWVFXp9
+P1OWkbo2z5XkKjoeobM/zKDESJR78h+YQAN9IOKFjL/u/Gzrk1oEgByCABXOX+H5
+hfucrq5U3bbcKy4e5tYgnnZxqpELv3fN/2l8iZknHEh5aYNT5WXVHpD/8u2rMmwm
+I9YTEMueEtmVy0ZV3opUzOlC+3ZUwjmvAJtdfJyeVW/VMy3Hw3Ih0Fij91rO613V
+7n72ggVlJiX25jYyT4AXlaGfAOMndJNVgBps0RArOBYsJRPnvfHlLi5cfjVd7vYx
+QhGX9ODYuvyJ/rW70dMVikeSjlBDKS08tvdqOgtiYy4yhtY4ijQC9BmCE9H9gOxU
+FN297iLimAxr0EVsED96fP96TbDGILWsfJuxAvoqmpkElv8J+P1/F7to2QARAQAB
+zU9Sb2NreSBFbnRlcnByaXNlIFNvZnR3YXJlIEZvdW5kYXRpb24gLSBSZWxlYXNl
+IGtleSAyMDIyIDxyZWxlbmdAcm9ja3lsaW51eC5vcmc+wsGKBBMBCAA0BQJieUZL
+FiEEIcslauFvxUxuZSlJcC1CbTUNJ10CGwMCHgECGQEDCwkHAhUIAxYAAgIiAQAK
+CRBwLUJtNQ0nXWQ5D/9472seOyRO6//bQ2ns3w9lE+aTLlJ5CY0GSTb4xNuyv+AD
+IXpgvLSMtTR0fp9GV3vMw6QIWsehDqt7O5xKWi+3tYdaXRpb1cvnh8r/oCcvI4uL
+k8kImNgsx+Cj+drKeQo03vFxBTDi1BTQFkfEt32fA2Aw5gYcGElM717sNMAMQFEH
+P+OW5hYDH4kcLbtUypPXFbcXUbaf6jUjfiEp5lLjqquzAyDPLlkzMr5RVa9n3/rI
+R6OQp5loPVzCRZMgDLALBU2TcFXLVP+6hAW8qM77c+q/rOysP+Yd+N7GAd0fvEvA
+mfeA4Y6dP0mMRu96EEAJ1qSKFWUul6K6nuqy+JTxktpw8F/IBAz44na17Tf02MJH
+GCUWyM0n5vuO5kK+Ykkkwd+v43ZlqDnwG7akDkLwgj6O0QNx2TGkdgt3+C6aHN5S
+MiF0pi0qYbiN9LO0e05Ai2r3zTFC/pCaBWlG1ph2jx1pDy4yUVPfswWFNfe5I+4i
+CMHPRFsZNYxQnIA2Prtgt2YMwz3VIGI6DT/Z56Joqw4eOfaJTTQSXCANts/gD7qW
+D3SZXPc7wQD63TpDEjJdqhmepaTECbxN7x/p+GwIZYWJN+AYhvrfGXfjud3eDu8/
+i+YIbPKH1TAOMwiyxC106mIL705p+ORf5zATZMyB8Y0OvRIz5aKkBDFZM2QN6A==
+=PzIf
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+		fi
 	fi
 	cat <<- "EOF" > /etc/yum.repos.d/Rocky-BaseOS.repo
 [BaseOS]
 name=Rocky-$releasever - Base
-mirrorlist=http://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-8
+mirrorlist=http://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial


### PR DESCRIPTION
- sources/rhel: Check directory before listing its entries
- sources/rocky: Fix gpg key and mirrorlist for v9
