### PR TITLE
manages/{dnf,yum}: Use --nobest on package updates

### DIFF
--- a/managers/dnf.go
+++ b/managers/dnf.go
@@ -33,6 +33,7 @@ func (m *dnf) load() error {
 		},
 		update: []string{
 			"upgrade",
+			"--nobest",
 		},
 		clean: []string{
 			"clean", "all",

--- a/managers/yum.go
+++ b/managers/yum.go
@@ -56,6 +56,7 @@ func (m *yum) load() error {
 		},
 		update: []string{
 			"update",
+			"--nobest",
 		},
 	}
 


### PR DESCRIPTION
This uses the --nobest flag when updating packages. It fixes an issue
where packages cannot be updated to the best update candidate in the
packing stage, i.e. `pack-lxc` or `pack-lxd. It only happens when
running `build-dir` and `pack-lxc` or `pack-lxd` separately, not when
running `build-lxc` or `build-lxd`.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
