### PR TITLE
systemd: Mask systemd-binfmt.service

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -751,6 +751,7 @@ fix_systemd_mask systemd-modules-load.service
 fix_systemd_mask systemd-pstore.service
 fix_systemd_mask ua-messaging.service
 fix_systemd_mask systemd-firstboot.service
+fix_systemd_mask systemd-binfmt.service
 if [ ! -e /dev/tty1 ]; then
 	fix_systemd_mask vconsole-setup-kludge@tty1.service
 fi


### PR DESCRIPTION
This masks the systemd-binfmt.service as it fails for containers.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
