### PR TITLE
image,shared: Allow specifying compression level

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -91,6 +91,9 @@ following values:
   - lzop
   - xz (default)
   - zstd
+
+For supported compression methods, a compression level can be specified with
+method-N, where N is an integer, e.g. gzip-9.
 `
 
 type cmdGlobal struct {

--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -88,6 +88,7 @@ following values:
   - gzip
   - lzip
   - lzma
+  - lzo
   - lzop
   - xz (default)
   - zstd

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -29,8 +29,16 @@ func (c *cmdLXC) commandBuild() *cobra.Command {
 
 %s
 `, compressionDescription),
-		Args:    cobra.RangeArgs(1, 2),
-		PreRunE: c.global.preRunBuild,
+		Args: cobra.RangeArgs(1, 2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check compression arguments
+			_, _, err := shared.ParseCompression(c.flagCompression)
+			if err != nil {
+				return fmt.Errorf("Failed to parse compression level: %w", err)
+			}
+
+			return c.global.preRunBuild(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			overlayDir, cleanup, err := c.global.getOverlayDir()
 			if err != nil {
@@ -65,8 +73,16 @@ func (c *cmdLXC) commandPack() *cobra.Command {
 
 %s
 `, compressionDescription),
-		Args:    cobra.RangeArgs(2, 3),
-		PreRunE: c.global.preRunPack,
+		Args: cobra.RangeArgs(2, 3),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check compression arguments
+			_, _, err := shared.ParseCompression(c.flagCompression)
+			if err != nil {
+				return fmt.Errorf("Failed to parse compression level: %w", err)
+			}
+
+			return c.global.preRunPack(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			overlayDir, cleanup, err := c.global.getOverlayDir()
 			if err != nil {

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -48,6 +48,19 @@ func (c *cmdLXD) commandBuild() *cobra.Command {
 				return errors.New("--type needs to be one of ['split', 'unified']")
 			}
 
+			// Check compression arguments
+			_, _, err := shared.ParseCompression(c.flagCompression)
+			if err != nil {
+				return fmt.Errorf("Failed to parse compression level: %w", err)
+			}
+
+			if c.flagType == "split" {
+				_, _, err := shared.ParseSquashfsCompression(c.flagCompression)
+				if err != nil {
+					return fmt.Errorf("Failed to parse compression level: %w", err)
+				}
+			}
+
 			// Check dependencies
 			if c.flagVM {
 				err := c.checkVMDependencies()
@@ -102,6 +115,19 @@ func (c *cmdLXD) commandPack() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !lxd.StringInSlice(c.flagType, []string{"split", "unified"}) {
 				return errors.New("--type needs to be one of ['split', 'unified']")
+			}
+
+			// Check compression arguments
+			_, _, err := shared.ParseCompression(c.flagCompression)
+			if err != nil {
+				return fmt.Errorf("Failed to parse compression level: %w", err)
+			}
+
+			if c.flagType == "split" {
+				_, _, err := shared.ParseSquashfsCompression(c.flagCompression)
+				if err != nil {
+					return fmt.Errorf("Failed to parse compression level: %w", err)
+				}
 			}
 
 			// Check dependencies

--- a/doc/building.md
+++ b/doc/building.md
@@ -52,6 +52,9 @@ following values:
   - xz (default)
   - zstd
 
+For supported compression methods, a compression level can be specified with
+method-N, where N is an integer, e.g. gzip-9.
+
 Usage:
   distrobuilder build-lxc <filename|-> [target dir] [--compression=COMPRESSION] [flags]
 
@@ -101,6 +104,9 @@ following values:
   - lzop
   - xz (default)
   - zstd
+
+For supported compression methods, a compression level can be specified with
+method-N, where N is an integer, e.g. gzip-9.
 
 Usage:
   distrobuilder build-lxd <filename|-> [target dir] [--type=TYPE] [--compression=COMPRESSION] [--import-into-lxd] [flags]

--- a/doc/building.md
+++ b/doc/building.md
@@ -48,6 +48,7 @@ following values:
   - gzip
   - lzip
   - lzma
+  - lzo
   - lzop
   - xz (default)
   - zstd
@@ -101,6 +102,7 @@ following values:
   - gzip
   - lzip
   - lzma
+  - lzo
   - lzop
   - xz (default)
   - zstd

--- a/image/lxd.go
+++ b/image/lxd.go
@@ -139,8 +139,8 @@ func (l *LXDImage) Build(unified bool, compression string, vm bool) (string, str
 			rootfsFile = filepath.Join(l.targetDir, "rootfs.squashfs")
 			args := []string{l.sourceDir, rootfsFile, "-noappend", "-b", "1M", "-no-progress", "-no-recovery"}
 
-			compression, level, err := shared.ParseSquashfsCompression(compression)
-			if err != nil {
+			compression, level, parseErr := shared.ParseSquashfsCompression(compression)
+			if parseErr != nil {
 				return "", "", fmt.Errorf("Failed to parse compression level: %w", err)
 			}
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -307,7 +307,13 @@ func ParseCompression(compression string) (string, *int, error) {
 			if 1 <= level && level <= 22 {
 				return compression, &level, nil
 			}
-		case "bzip2", "gzip", "lzop":
+		case "bzip2", "gzip", "lzo", "lzop":
+			// The standalone tool is named lzop, but mksquashfs
+			// accepts only lzo. For convenience, accept both.
+			if compression == "lzo" {
+				compression = "lzop"
+			}
+
 			if 1 <= level && level <= 9 {
 				return compression, &level, nil
 			}
@@ -320,6 +326,10 @@ func ParseCompression(compression string) (string, *int, error) {
 		}
 
 		return "", nil, fmt.Errorf("Invalid compression level %q for method %q", level, compression)
+	}
+
+	if compression == "lzo" {
+		compression = "lzop"
 	}
 
 	return compression, nil, nil
@@ -342,7 +352,13 @@ func ParseSquashfsCompression(compression string) (string, *int, error) {
 			if 1 <= level && level <= 22 {
 				return compression, &level, nil
 			}
-		case "gzip", "lzo":
+		case "gzip", "lzo", "lzop":
+			// mkskquashfs accepts only lzo, but the standalone
+			// tool is named lzop. For convenience, accept both.
+			if compression == "lzop" {
+				compression = "lzo"
+			}
+
 			if 1 <= level && level <= 9 {
 				return compression, &level, nil
 			}
@@ -351,6 +367,10 @@ func ParseSquashfsCompression(compression string) (string, *int, error) {
 		}
 
 		return "", nil, fmt.Errorf("Invalid squashfs compression level %q for method %q", level, compression)
+	}
+
+	if compression == "lzop" {
+		compression = "lzo"
 	}
 
 	if shared.StringInSlice(compression, []string{"gzip", "lzo", "lz4", "xz", "zstd", "lzma"}) {

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -112,3 +112,96 @@ func TestSetEnvVariables(t *testing.T) {
 	require.False(t, set, "Expected 'BAR' to be unset")
 	require.Empty(t, val)
 }
+
+func TestParseCompression(t *testing.T) {
+	tests := []struct {
+		compression         string
+		expectedCompression string
+		expectLevel         bool
+		expectedLevel       int
+		shouldFail          bool
+	}{
+		{
+			"gzip", "gzip", false, 0 /* irrelevant */, false,
+		},
+		{
+			"gzip-1", "gzip", true, 1, false,
+		},
+		{
+			"gzip-10", "", false, 0, true,
+		},
+		{
+			"zstd-22", "zstd", true, 22, false,
+		},
+		{
+			"gzip-0", "", false, 0, true,
+		},
+		{
+			"unknown-1", "", false, 0, true,
+		},
+	}
+
+	for i, tt := range tests {
+		log.Printf("Running test #%d: %s", i, tt.compression)
+		compression, level, err := ParseCompression(tt.compression)
+
+		if tt.shouldFail {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCompression, compression)
+			if tt.expectLevel {
+				require.NotNil(t, level)
+				require.Equal(t, tt.expectedLevel, *level)
+			}
+		}
+	}
+}
+
+func TestSquashfsParseCompression(t *testing.T) {
+	tests := []struct {
+		compression         string
+		expectedCompression string
+		expectLevel         bool
+		expectedLevel       int
+		shouldFail          bool
+	}{
+		{
+			"gzip", "gzip", false, 0 /* irrelevant */, false,
+		},
+		{
+			"gzip-1", "gzip", true, 1, false,
+		},
+		{
+			"gzip-10", "", false, 0, true,
+		},
+		{
+			"zstd-22", "zstd", true, 22, false,
+		},
+		{
+			"gzip-0", "", false, 0, true,
+		},
+		{
+			"invalid", "", false, 0, true,
+		},
+		{
+			"xz-1", "", false, 0, true,
+		},
+	}
+
+	for i, tt := range tests {
+		log.Printf("Running test #%d: %s", i, tt.compression)
+		compression, level, err := ParseSquashfsCompression(tt.compression)
+
+		if tt.shouldFail {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedCompression, compression)
+			if tt.expectLevel {
+				require.NotNil(t, level)
+				require.Equal(t, tt.expectedLevel, *level)
+			}
+		}
+	}
+}

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -139,6 +139,12 @@ func TestParseCompression(t *testing.T) {
 		{
 			"unknown-1", "", false, 0, true,
 		},
+		{
+			"lzo", "lzop", false, 0 /* irrelevant */, false,
+		},
+		{
+			"lzo-9", "lzop", true, 9, false,
+		},
 	}
 
 	for i, tt := range tests {
@@ -186,6 +192,12 @@ func TestSquashfsParseCompression(t *testing.T) {
 		},
 		{
 			"xz-1", "", false, 0, true,
+		},
+		{
+			"lzop", "lzo", false, 0 /* irrelevant */, false,
+		},
+		{
+			"lzop-9", "lzo", true, 9, false,
 		},
 	}
 


### PR DESCRIPTION
Allow specifying compression levels when the underlying tool or mksquashfs understands it. For example, gzip-1 or zstd-22. Compression levels are checked pre-run.

Signed-off-by: James Ye <jamesye@google.com>