### PR TITLE
main: Log error when main command fails

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -220,6 +220,10 @@ func main() {
 	// Run the main command and handle errors
 	err := app.Execute()
 	if err != nil {
+		if globalCmd.logger != nil {
+			globalCmd.logger.WithFields(logrus.Fields{"err": err}).Error("Failed running distrobuilder")
+		}
+
 		globalCmd.postRun(nil, nil)
 		os.Exit(1)
 	}

--- a/sources/openeuler-http_test.go
+++ b/sources/openeuler-http_test.go
@@ -18,7 +18,7 @@ func TestGetLatestRelease(t *testing.T) {
 		{
 			"https://repo.openeuler.org/",
 			"22.03",
-			"22.03-LTS",
+			"22.03-LTS-SP1",
 			false,
 		},
 		{


### PR DESCRIPTION
This logs the error when the main command fails. We've been seeing failures for no apparent reason, so this might help find the issue.
