### PR TITLE
main: Ensure main error is logged

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -222,6 +222,8 @@ func main() {
 	if err != nil {
 		if globalCmd.logger != nil {
 			globalCmd.logger.WithFields(logrus.Fields{"err": err}).Error("Failed running distrobuilder")
+		} else {
+			fmt.Fprintf(os.Stderr, "Failed running distrobuilder: %s\n", err.Error())
 		}
 
 		globalCmd.postRun(nil, nil)


### PR DESCRIPTION
This ensures that the error message of the main command is always logged
even if the logger itself is not configured. In this case, the error
will be printed to stderr.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
