### PR TITLE
doc: only include GitHub link in the footer for actual pages

### DIFF
--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -64,7 +64,7 @@
          rel="nofollow">Show source</a>
     </div>
     {%- endif %}
-    {% if github_url and github_version and github_folder and github_filetype %}
+    {% if github_url and github_version and github_folder and github_filetype and has_source and sourcename %}
     <div class="edit-github">
       <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}.{{ github_filetype }}">Edit on GitHub</a>
     </div>


### PR DESCRIPTION
There's no GitHub source for pages that are generated.

This should fix the link checker on the website.