### PR TITLE
Fix broken link to use.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $HOME/go/bin/distrobuilder
 
 ## How to use
 
-See [How to use `distrobuilder`](doc/howto/use.md) for instructions.
+See [How to use `distrobuilder`](doc/howto/build.md) for instructions.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Doc link to use.md is broken. I suspect doc/howto/build.md is the right target. 