### PR TITLE
doc: Update actions regards to the hook post-files

### DIFF
--- a/doc/reference/actions.md
+++ b/doc/reference/actions.md
@@ -30,4 +30,5 @@ After the package manager has installed the requested packages, all `post-packag
 For more on `packages`, see [packages](packages.md).
 
 And last, after the `files` section has been processed, all `post-files` actions are run.
+This action runs only for `build-lxc`, `build-lxd`, `pack-lxc`, and `pack-lxd`.
 For more on `files`, see [generators](generators.md).


### PR DESCRIPTION
In #600 you can read that the `post-files`-hook is only executed for certain commandos. I think this is worth to be documented.