### PR TITLE
Add `--with-post-files` flag to `build-dir` command

### DIFF
--- a/doc/howto/build.md
+++ b/doc/howto/build.md
@@ -10,9 +10,10 @@ Usage:
   distrobuilder build-dir <filename|-> <target dir> [flags]
 
 Flags:
-  -h, --help           help for build-dir
-      --keep-sources   Keep sources after build (default true)
-      --sources-dir    Sources directory for distribution tarballs (default "/tmp/distrobuilder")
+  -h, --help              help for build-dir
+      --keep-sources      Keep sources after build (default true)
+      --sources-dir       Sources directory for distribution tarballs (default "/tmp/distrobuilder")
+      --with-post-files   Run post-files actions
 
 Global Flags:
       --cache-dir         Cache directory


### PR DESCRIPTION
This adds the `--with-post-files` flag to the `build-dir` command. If set, it runs those `post-files` actions which don't have a `type` filter set.
