### PR TITLE
main: Check cmd in postRun function

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -460,7 +460,7 @@ func (c *cmdGlobal) preRunPack(cmd *cobra.Command, args []string) error {
 
 func (c *cmdGlobal) postRun(cmd *cobra.Command, args []string) error {
 	// If we're only validating, there's nothing to clean up.
-	if cmd.CalledAs() == "validate" {
+	if cmd != nil && cmd.CalledAs() == "validate" {
 		return nil
 	}
 


### PR DESCRIPTION
If distrobuilder fails for any reason, postRun is called with nil
arguments. This caused a panic as it was trying to the cmd argument
which would be nil in this case.

This adds a nil check.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
