### PR TITLE
Drop support for upstart (no longer used)

### DIFF
--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -102,14 +102,6 @@ files:
         - create
         - copy
 
-  - generator: upstart-tty
-    path: /etc/init/lxc-tty.conf
-
-  - generator: cloud-init
-    name: user-data
-    content: |-
-      Here goes the user-data
-
 packages:
   manager: apt
   custom_manager:

--- a/doc/reference/generators.md
+++ b/doc/reference/generators.md
@@ -10,7 +10,6 @@ Available generators are
 * [`hosts`](#hosts)
 * [`remove`](#remove)
 * [`template`](#template)
-* [`upstart_tty`](#upstart_tty)
 * [`lxd-agent`](#lxd-agent)
 * [`fstab`](#fstab)
 
@@ -108,11 +107,6 @@ The `when` key can be one or more of:
 * start (run every time the container is started)
 
 See {ref}`lxd:image-format` in the LXD documentation for more information.
-
-## `upstart_tty`
-
-This generator creates an upstart job which prevents certain TTYs from starting.
-The job script is written to `path`.
 
 ## `lxd-agent`
 

--- a/generators/cloud-init.go
+++ b/generators/cloud-init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	lxd "github.com/lxc/lxd/shared"
@@ -41,36 +40,6 @@ func (g *cloudInit) RunLXC(img *image.LXCImage, target shared.DefinitionTargetLX
 		})
 		if err != nil {
 			return fmt.Errorf("Failed to walk file tree %q: %w", fullPath, err)
-		}
-	}
-
-	// With upstart:
-	// Remove all symlinks to /etc/rc.d/init.d/cloud-{init-local,config,init,final} in /etc/rc.d/rc<runlevel>.d/*
-	re := regexp.MustCompile(`^[KS]\d+cloud-(?:config|final|init|init-local)$`)
-
-	for i := 0; i <= 6; i++ {
-		fullPath := filepath.Join(g.sourceDir, fmt.Sprintf("/etc/rc.d/rc%d.d", i))
-
-		if !lxd.PathExists(fullPath) {
-			continue
-		}
-
-		err := filepath.Walk(fullPath, func(path string, info os.FileInfo, err error) error {
-			if info.IsDir() {
-				return nil
-			}
-
-			if re.MatchString(info.Name()) {
-				err := os.Remove(path)
-				if err != nil {
-					return fmt.Errorf("Failed to remove file %q: %w", path, err)
-				}
-			}
-
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("Failed walking %q: %w", fullPath, err)
 		}
 	}
 

--- a/generators/cloud-init_test.go
+++ b/generators/cloud-init_test.go
@@ -40,20 +40,6 @@ func TestCloudInitGeneratorRunLXC(t *testing.T) {
 		require.FileExists(t, fullPath)
 	}
 
-	for i := 0; i <= 6; i++ {
-		dir := filepath.Join(rootfsDir, "etc", "rc.d", fmt.Sprintf("rc%d.d", i))
-
-		err = os.MkdirAll(dir, 0755)
-		require.NoError(t, err)
-
-		for _, f := range []string{"cloud-init-local", "cloud-config", "cloud-init", "cloud-final"} {
-			fullPath := filepath.Join(dir, fmt.Sprintf("S99%s", f))
-			err = os.Symlink("/dev/null", fullPath)
-			require.NoError(t, err)
-			require.FileExists(t, fullPath)
-		}
-	}
-
 	// Disable cloud-init
 	err = generator.RunLXC(nil, shared.DefinitionTargetLXC{})
 	require.NoError(t, err)

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -439,7 +439,6 @@ func (d *Definition) Validate() error {
 		"hostname",
 		"hosts",
 		"remove",
-		"upstart-tty",
 		"cloud-init",
 		"lxd-agent",
 		"fstab",


### PR DESCRIPTION
AFAIK, upstart was used by CentOS before 7 and Ubuntu before 15.10. According to https://en.wikipedia.org/wiki/Upstart_(software) only ChromeOS and ChromiumOS are still using upstart but those are not something distrobuilder support building.