### PR TITLE
lxd-generator: Fix masking units created by generator

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -837,8 +837,10 @@ for d in /etc/systemd/system /usr/lib/systemd/system /lib/systemd/system; do
 	fi
 
 	find "${d}" -maxdepth 1 -type l | while read -r f; do
-		if [ "$(readlink "${f}")" = "/dev/null" ]; then
-			fix_systemd_mask "$(basename "${f}")"
+		unit="$(basename "${f}")"
+
+		if [ "${unit}" = "network-device-down.service" ] && [ "$(readlink "${f}")" = "/dev/null" ]; then
+			fix_systemd_mask "${unit}"
 		fi
 	done
 done


### PR DESCRIPTION
Only allow masking units actually created by the lxc system-generator.
Currently, this is only network-device-down.service.

Fixes #739

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
