### PR TITLE
definition: Add Source.Components

### DIFF
--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -21,6 +21,8 @@ source:
   suite: suite
   same_as: bionic
   skip_verification: false
+  components:
+    - main
 
 targets:
   lxc:

--- a/doc/reference/source.md
+++ b/doc/reference/source.md
@@ -13,6 +13,7 @@ source:
     suite: <string>
     same_as: <boolean>
     skip_verification: <boolean>
+    components: <array>
 ```
 
 The `downloader` field defines a downloader which pulls a rootfs image which will be used as a starting point.
@@ -64,6 +65,8 @@ If the `same_as` field is set, distrobuilder creates a temporary symlink in `/us
 This can be used if you want to run `debootstrap foo` but `foo` is missing due to `debootstrap` not being up-to-date.
 
 If `skip_verification` is true, the source tarball is not verified.
+
+If the `components` field is set, `debootstrap` will use packages from the listed components.
 
 If a package set has the `early` flag enabled, that list of packages will be installed
 while the source is being downloaded. (Note that `early` packages are only supported by

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -166,6 +166,7 @@ type DefinitionSource struct {
 	Suite            string   `yaml:"suite,omitempty"`
 	SameAs           string   `yaml:"same_as,omitempty"`
 	SkipVerification bool     `yaml:"skip_verification,omitempty"`
+	Components       []string `yaml:"components,omitempty"`
 }
 
 // A DefinitionTargetLXCConfig represents the config part of the metadata.

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -55,6 +55,10 @@ func (s *debootstrap) Run() error {
 		args = append(args, fmt.Sprintf("--exclude=%s", strings.Join(earlyPackagesRemove, ",")))
 	}
 
+	if len(s.definition.Source.Components) > 0 {
+		args = append(args, fmt.Sprintf("--components=%s", strings.Join(s.definition.Source.Components, ",")))
+	}
+
 	if len(s.definition.Source.Keys) > 0 {
 		keyring, err := s.CreateGPGKeyring()
 		if err != nil {


### PR DESCRIPTION
This is important for derivatives that can't be built with the main component alone, e.g., Astra Linux.
This allows to specify other components.