### PR TITLE
2023 07 08/revert filters

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -179,12 +179,6 @@ func main() {
 
 				globalCmd.flagCacheDir = dir
 			}
-
-			// Set VM target type if we're building or packing a VM.
-			isTargetVM, _ := cmd.Flags().GetBool("vm")
-			if isTargetVM {
-				globalCmd.definition.Targets.Type = shared.DefinitionFilterTypeVM
-			}
 		},
 		PersistentPostRunE: globalCmd.postRun,
 		CompletionOptions:  cobra.CompletionOptions{DisableDefaultCmd: true},

--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -169,38 +169,6 @@ func main() {
 				return
 			}
 
-			// Get the image definition
-			globalCmd.definition, err = getDefinition(args[0], globalCmd.flagOptions)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed reading definition: %s\n", err)
-				os.Exit(1)
-			}
-
-			// Set VM target type if we're building or packing a VM.
-			isTargetVM, _ := cmd.Flags().GetBool("vm")
-			if isTargetVM {
-				globalCmd.definition.Targets.Type = shared.DefinitionFilterTypeVM
-			}
-
-			// Get image targets depending on the subcommand and flags.
-			var imageTargets shared.ImageTarget
-
-			if strings.HasPrefix(cmd.CalledAs(), "build-") {
-				imageTargets = shared.ImageTargetUndefined
-			}
-
-			if cmd.CalledAs() != "build-dir" {
-				imageTargets |= shared.ImageTargetAll
-			}
-
-			if isTargetVM {
-				imageTargets |= shared.ImageTargetVM
-			} else {
-				imageTargets |= shared.ImageTargetContainer
-			}
-
-			globalCmd.definition.ApplyFilters(imageTargets)
-
 			// Create temp directory if the cache directory isn't explicitly set
 			if globalCmd.flagCacheDir == "" {
 				dir, err := os.MkdirTemp("/var/cache", "distrobuilder.")
@@ -210,6 +178,12 @@ func main() {
 				}
 
 				globalCmd.flagCacheDir = dir
+			}
+
+			// Set VM target type if we're building or packing a VM.
+			isTargetVM, _ := cmd.Flags().GetBool("vm")
+			if isTargetVM {
+				globalCmd.definition.Targets.Type = shared.DefinitionFilterTypeVM
 			}
 		},
 		PersistentPostRunE: globalCmd.postRun,
@@ -330,6 +304,12 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 	err = os.MkdirAll(c.sourceDir, 0755)
 	if err != nil {
 		return fmt.Errorf("Failed to create directory %q: %w", c.sourceDir, err)
+	}
+
+	// Get the image definition
+	c.definition, err = getDefinition(args[0], c.flagOptions)
+	if err != nil {
+		return fmt.Errorf("Failed to get definition: %w", err)
 	}
 
 	// Create cache directory if we also plan on creating LXC or LXD images
@@ -485,6 +465,12 @@ func (c *cmdGlobal) preRunPack(cmd *cobra.Command, args []string) error {
 	c.targetDir = "."
 	if len(args) == 3 {
 		c.targetDir = args[2]
+	}
+
+	// Get the image definition
+	c.definition, err = getDefinition(args[0], c.flagOptions)
+	if err != nil {
+		return fmt.Errorf("Failed to get definition: %w", err)
 	}
 
 	return nil

--- a/distrobuilder/main_build-dir.go
+++ b/distrobuilder/main_build-dir.go
@@ -27,6 +27,10 @@ func (c *cmdBuildDir) command() *cobra.Command {
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			// Run global generators
 			for _, file := range c.global.definition.Files {
+				if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, 0) {
+					continue
+				}
+
 				generator, err := generators.Load(file.Generator, c.global.logger, c.global.flagCacheDir, c.global.targetDir, file, *c.global.definition)
 				if err != nil {
 					return fmt.Errorf("Failed to load generator %q: %w", file.Generator, err)

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -187,6 +187,12 @@ func (c *cmdLXC) run(cmd *cobra.Command, args []string, overlayDir string) error
 		c.global.flagCacheDir, *c.global.definition)
 
 	for _, file := range c.global.definition.Files {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, shared.ImageTargetUndefined|shared.ImageTargetAll|shared.ImageTargetContainer) {
+			c.global.logger.WithField("generator", file.Generator).Info("Skipping generator")
+
+			continue
+		}
+
 		generator, err := generators.Load(file.Generator, c.global.logger, c.global.flagCacheDir, overlayDir, file, *c.global.definition)
 		if err != nil {
 			return fmt.Errorf("Failed to load generator %q: %w", file.Generator, err)

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -155,6 +155,10 @@ func (c *cmdLXD) commandPack() *cobra.Command {
 				}()
 			}
 
+			if c.flagVM {
+				c.global.definition.Targets.Type = "vm"
+			}
+
 			err = c.runPack(cmd, args, overlayDir)
 			if err != nil {
 				return fmt.Errorf("Failed to pack image: %w", err)

--- a/distrobuilder/main_lxd.go
+++ b/distrobuilder/main_lxd.go
@@ -262,6 +262,10 @@ func (c *cmdLXD) run(cmd *cobra.Command, args []string, overlayDir string) error
 	}
 
 	for _, file := range c.global.definition.Files {
+		if !shared.ApplyFilter(&file, c.global.definition.Image.Release, c.global.definition.Image.ArchitectureMapped, c.global.definition.Image.Variant, c.global.definition.Targets.Type, imageTargets) {
+			continue
+		}
+
 		generator, err := generators.Load(file.Generator, c.global.logger, c.global.flagCacheDir, overlayDir, file, *c.global.definition)
 		if err != nil {
 			return fmt.Errorf("Failed to load generator %q: %w", file.Generator, err)

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -94,9 +94,19 @@ func Load(ctx context.Context, managerName string, logger *logrus.Logger, defini
 
 // ManagePackages manages packages.
 func (m *Manager) ManagePackages(imageTarget shared.ImageTarget) error {
+	var validSets []shared.DefinitionPackagesSet
+
+	for _, set := range m.def.Packages.Sets {
+		if !shared.ApplyFilter(&set, m.def.Image.Release, m.def.Image.ArchitectureMapped, m.def.Image.Variant, m.def.Targets.Type, imageTarget) {
+			continue
+		}
+
+		validSets = append(validSets, set)
+	}
+
 	// If there's nothing to install or remove, and no updates need to be performed,
 	// we can exit here.
-	if len(m.def.Packages.Sets) == 0 && !m.def.Packages.Update {
+	if len(validSets) == 0 && !m.def.Packages.Update {
 		return nil
 	}
 
@@ -127,7 +137,7 @@ func (m *Manager) ManagePackages(imageTarget shared.ImageTarget) error {
 		}
 	}
 
-	for _, set := range optimizePackageSets(m.def.Packages.Sets) {
+	for _, set := range optimizePackageSets(validSets) {
 		if set.Action == "install" {
 			err = m.mgr.install(set.Packages, set.Flags)
 		} else if set.Action == "remove" {
@@ -158,6 +168,10 @@ func (m *Manager) ManageRepositories(imageTarget shared.ImageTarget) error {
 	}
 
 	for _, repo := range m.def.Packages.Repositories {
+		if !shared.ApplyFilter(&repo, m.def.Image.Release, m.def.Image.ArchitectureMapped, m.def.Image.Variant, m.def.Targets.Type, imageTarget) {
+			continue
+		}
+
 		// Run template on repo.URL
 		repo.URL, err = shared.RenderTemplate(repo.URL, m.def)
 		if err != nil {

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -171,11 +171,10 @@ type DefinitionSource struct {
 
 // A DefinitionTargetLXCConfig represents the config part of the metadata.
 type DefinitionTargetLXCConfig struct {
-	DefinitionFilter `yaml:",inline"`
-	Type             string `yaml:"type"`
-	Before           uint   `yaml:"before,omitempty"`
-	After            uint   `yaml:"after,omitempty"`
-	Content          string `yaml:"content"`
+	Type    string `yaml:"type"`
+	Before  uint   `yaml:"before,omitempty"`
+	After   uint   `yaml:"after,omitempty"`
+	Content string `yaml:"content"`
 }
 
 // A DefinitionTargetLXC represents LXC specific files as part of the metadata.
@@ -691,17 +690,6 @@ func (d *Definition) ApplyFilters(imageTargets ImageTarget) {
 		}
 
 		newDefinition.Actions = append(newDefinition.Actions, action)
-	}
-
-	// Filter targets
-	newDefinition.Targets.LXC.Config = []DefinitionTargetLXCConfig{}
-
-	for _, config := range d.Targets.LXC.Config {
-		if !d.applyFilter(&config, imageTargets) {
-			continue
-		}
-
-		newDefinition.Targets.LXC.Config = append(newDefinition.Targets.LXC.Config, config)
 	}
 
 	*d = newDefinition

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -241,9 +241,8 @@ type DefinitionMappings struct {
 
 // DefinitionEnvVars defines custom environment variables.
 type DefinitionEnvVars struct {
-	DefinitionFilter `yaml:",inline"`
-	Key              string `yaml:"key"`
-	Value            string `yaml:"value"`
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 // DefinitionEnv represents the config part of the environment section.
@@ -703,17 +702,6 @@ func (d *Definition) ApplyFilters(imageTargets ImageTarget) {
 		}
 
 		newDefinition.Targets.LXC.Config = append(newDefinition.Targets.LXC.Config, config)
-	}
-
-	// Filter environment variables
-	newDefinition.Environment.EnvVariables = []DefinitionEnvVars{}
-
-	for _, envVar := range d.Environment.EnvVariables {
-		if !d.applyFilter(&envVar, imageTargets) {
-			continue
-		}
-
-		newDefinition.Environment.EnvVariables = append(newDefinition.Environment.EnvVariables, envVar)
 	}
 
 	*d = newDefinition

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -536,6 +536,10 @@ func (d *Definition) GetRunnableActions(trigger string, imageTarget ImageTarget)
 			continue
 		}
 
+		if !ApplyFilter(&action, d.Image.Release, d.Image.ArchitectureMapped, d.Image.Variant, d.Targets.Type, imageTarget) {
+			continue
+		}
+
 		out = append(out, action)
 	}
 
@@ -550,7 +554,7 @@ func (d *Definition) GetEarlyPackages(action string) []string {
 	normal := []DefinitionPackagesSet{}
 
 	for _, set := range d.Packages.Sets {
-		if set.Early && set.Action == action {
+		if set.Early && set.Action == action && ApplyFilter(&set, d.Image.Release, d.Image.ArchitectureMapped, d.Image.Variant, d.Targets.Type, 0) {
 			early = append(early, set.Packages...)
 		} else {
 			normal = append(normal, set)
@@ -586,113 +590,6 @@ func (d *Definition) getMappedArchitecture() (string, error) {
 	}
 
 	return arch, nil
-}
-
-// ApplyFilter returns true if the filter matches.
-func (d *Definition) applyFilter(filter Filter, acceptedImageTargets ImageTarget) bool {
-	if len(filter.GetReleases()) > 0 && !shared.StringInSlice(d.Image.Release, filter.GetReleases()) {
-		return false
-	}
-
-	if len(filter.GetArchitectures()) > 0 && !shared.StringInSlice(d.Image.ArchitectureMapped, filter.GetArchitectures()) {
-		return false
-	}
-
-	if len(filter.GetVariants()) > 0 && !shared.StringInSlice(d.Image.Variant, filter.GetVariants()) {
-		return false
-	}
-
-	types := filter.GetTypes()
-
-	if (acceptedImageTargets == 0 || acceptedImageTargets&ImageTargetUndefined > 0) && len(types) == 0 {
-		return true
-	}
-
-	hasTargetType := func(targetType DefinitionFilterType) bool {
-		for _, t := range types {
-			if t == targetType {
-				return true
-			}
-		}
-
-		return false
-	}
-
-	if acceptedImageTargets&ImageTargetAll > 0 {
-		if len(types) == 2 && hasTargetType(d.Targets.Type) {
-			return true
-		}
-	}
-
-	if acceptedImageTargets&ImageTargetContainer > 0 {
-		if d.Targets.Type == DefinitionFilterTypeContainer && hasTargetType(d.Targets.Type) {
-			return true
-		}
-	}
-
-	if acceptedImageTargets&ImageTargetVM > 0 {
-		if d.Targets.Type == DefinitionFilterTypeVM && hasTargetType(d.Targets.Type) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// ApplyFilters removes those parts of the definition which are excluded by the filters.
-func (d *Definition) ApplyFilters(imageTargets ImageTarget) {
-	newDefinition := Definition{
-		Actions:     []DefinitionAction{},
-		Environment: d.Environment,
-		Files:       []DefinitionFile{},
-		Image:       d.Image,
-		Mappings:    d.Mappings,
-		Packages:    d.Packages,
-		Source:      d.Source,
-		Targets:     d.Targets,
-	}
-
-	// Filter files
-	for _, file := range d.Files {
-		if !d.applyFilter(&file, imageTargets) {
-			continue
-		}
-
-		newDefinition.Files = append(newDefinition.Files, file)
-	}
-
-	// Filter repositories
-	newDefinition.Packages.Repositories = []DefinitionPackagesRepository{}
-
-	for _, repo := range d.Packages.Repositories {
-		if !d.applyFilter(&repo, imageTargets) {
-			continue
-		}
-
-		newDefinition.Packages.Repositories = append(newDefinition.Packages.Repositories, repo)
-	}
-
-	// Filter package sets
-	newDefinition.Packages.Sets = []DefinitionPackagesSet{}
-
-	for _, set := range d.Packages.Sets {
-		if !d.applyFilter(&set, imageTargets) {
-			continue
-		}
-
-		newDefinition.Packages.Sets = append(newDefinition.Packages.Sets, set)
-	}
-
-	// Filter actions
-	for _, action := range d.Actions {
-		if !d.applyFilter(&action, imageTargets) {
-			continue
-		}
-
-		newDefinition.Actions = append(newDefinition.Actions, action)
-	}
-
-	*d = newDefinition
 }
 
 func getFieldByTag(v reflect.Value, t reflect.Type, tag string) (reflect.Value, error) {
@@ -734,4 +631,55 @@ func getFieldByTag(v reflect.Value, t reflect.Type, tag string) (reflect.Value, 
 
 	// Return its value if it's a primitive type
 	return v, nil
+}
+
+// ApplyFilter returns true if the filter matches.
+func ApplyFilter(filter Filter, release string, architecture string, variant string, targetType DefinitionFilterType, acceptedImageTargets ImageTarget) bool {
+	if len(filter.GetReleases()) > 0 && !shared.StringInSlice(release, filter.GetReleases()) {
+		return false
+	}
+
+	if len(filter.GetArchitectures()) > 0 && !shared.StringInSlice(architecture, filter.GetArchitectures()) {
+		return false
+	}
+
+	if len(filter.GetVariants()) > 0 && !shared.StringInSlice(variant, filter.GetVariants()) {
+		return false
+	}
+
+	types := filter.GetTypes()
+
+	if (acceptedImageTargets == 0 || acceptedImageTargets&ImageTargetUndefined > 0) && len(types) == 0 {
+		return true
+	}
+
+	hasTargetType := func(targetType DefinitionFilterType) bool {
+		for _, t := range types {
+			if t == targetType {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if acceptedImageTargets&ImageTargetAll > 0 {
+		if len(types) == 2 && hasTargetType(targetType) {
+			return true
+		}
+	}
+
+	if acceptedImageTargets&ImageTargetContainer > 0 {
+		if targetType == DefinitionFilterTypeContainer && hasTargetType(targetType) {
+			return true
+		}
+	}
+
+	if acceptedImageTargets&ImageTargetVM > 0 {
+		if targetType == DefinitionFilterTypeVM && hasTargetType(targetType) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/shared/definition_test.go
+++ b/shared/definition_test.go
@@ -505,78 +505,61 @@ func TestDefinitionFilter(t *testing.T) {
 }
 
 func TestApplyFilter(t *testing.T) {
-	d := Definition{}
 	repo := DefinitionPackagesRepository{}
 
 	// Variants
 	repo.Variants = []string{"default"}
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "amd64", Variant: "default"}
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "amd64", Variant: "cloud"}
-	require.False(t, d.applyFilter(&repo, ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "cloud", "vm", 0))
 
 	// Architectures
 	repo.Architectures = []string{"amd64", "i386"}
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "amd64", Variant: "default"}
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "i386", Variant: "default"}
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "s390", Variant: "default"}
-	require.False(t, d.applyFilter(&repo, ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
+	require.True(t, ApplyFilter(&repo, "foo", "i386", "default", "vm", 0))
+	require.False(t, ApplyFilter(&repo, "foo", "s390", "default", "vm", 0))
 
 	// Releases
 	repo.Releases = []string{"foo"}
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "amd64", Variant: "default"}
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Image = DefinitionImage{Release: "bar", ArchitectureMapped: "amd64", Variant: "default"}
-	require.False(t, d.applyFilter(&repo, ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
+	require.False(t, ApplyFilter(&repo, "bar", "amd64", "default", "vm", 0))
 
 	// Targets
-	d.Image = DefinitionImage{Release: "foo", ArchitectureMapped: "amd64", Variant: "default"}
-	d.Targets.Type = DefinitionFilterTypeVM
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Targets.Type = DefinitionFilterTypeContainer
-	require.True(t, d.applyFilter(&repo, ImageTargetUndefined))
-	d.Targets.Type = DefinitionFilterTypeVM
-	require.False(t, d.applyFilter(&repo, ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	d.Targets.Type = DefinitionFilterTypeContainer
-	require.False(t, d.applyFilter(&repo, ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", 0))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetUndefined))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetAll|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetAll|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer|ImageTargetVM))
 
-	d.Targets.Type = DefinitionFilterTypeVM
 	repo.Types = []DefinitionFilterType{DefinitionFilterTypeVM}
-	require.True(t, d.applyFilter(&repo, ImageTargetVM))
-	require.True(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetVM))
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	d.Targets.Type = DefinitionFilterTypeContainer
-	require.False(t, d.applyFilter(&repo, ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetVM))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetAll|ImageTargetVM))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetAll|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", 0))
 
-	d.Targets.Type = DefinitionFilterTypeContainer
 	repo.Types = []DefinitionFilterType{DefinitionFilterTypeContainer}
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer))
-	require.True(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetContainer))
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	d.Targets.Type = DefinitionFilterTypeVM
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer))
-	require.False(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetContainer))
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetUndefined))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetAll|ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetAll|ImageTargetContainer))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", 0))
 
-	d.Targets.Type = DefinitionFilterTypeContainer
 	repo.Types = []DefinitionFilterType{DefinitionFilterTypeContainer, DefinitionFilterTypeVM}
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer))
-	require.True(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetContainer))
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	d.Targets.Type = DefinitionFilterTypeVM
-	require.True(t, d.applyFilter(&repo, ImageTargetAll|ImageTargetContainer))
-	require.True(t, d.applyFilter(&repo, ImageTargetContainer|ImageTargetVM))
-	require.False(t, d.applyFilter(&repo, ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetAll|ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "container", ImageTargetContainer|ImageTargetVM))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetAll|ImageTargetContainer))
+	require.True(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer|ImageTargetVM))
+	require.False(t, ApplyFilter(&repo, "foo", "amd64", "default", "vm", ImageTargetContainer))
 }
 
 func TestDefinitionFilterTypeUnmarshalYAML(t *testing.T) {


### PR DESCRIPTION
Revert the commits in https://github.com/lxc/distrobuilder/pull/744 .

That PR causes meta.tar.xz to lack the config.* and templates files, breaking 'lxc-create -t download'.