### PR TITLE
windows: Mount Windows ISO as UDF instead of ISO9660

### DIFF
--- a/distrobuilder/main_repack-windows.go
+++ b/distrobuilder/main_repack-windows.go
@@ -170,7 +170,7 @@ func (c *cmdRepackWindows) preRun(cmd *cobra.Command, args []string) error {
 	logger.Info("Mounting Windows ISO")
 
 	// Mount ISO
-	err = shared.RunCommand(c.global.ctx, nil, nil, "mount", "-t", "iso9660", "-o", "loop", args[0], c.global.sourceDir)
+	err = shared.RunCommand(c.global.ctx, nil, nil, "mount", "-t", "udf", "-o", "loop", args[0], c.global.sourceDir)
 	if err != nil {
 		return fmt.Errorf("Failed to mount %q at %q: %w", args[0], c.global.sourceDir, err)
 	}


### PR DESCRIPTION
Windows ISOs need to be mounted as UDF now otherwise no content will be
shown.

Signed-off-by: Thomas Hipp <thomashipp@gmail.com>
