### PR TITLE
udev: Trigger lxd-agent even on change events

### DIFF
--- a/generators/lxd-agent.go
+++ b/generators/lxd-agent.go
@@ -150,7 +150,9 @@ WantedBy=multi-user.target
 		udevPath = filepath.Join("/", "usr", "lib", "udev", "rules.d")
 	}
 
-	lxdAgentRules := `ACTION=="add", SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ACTION=="add", RUN+="/bin/systemctl start lxd-agent.service"`
+	lxdAgentRules := `ACTION=="add", SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd"
+SYMLINK=="virtio-ports/org.linuxcontainers.lxd", RUN+="/bin/systemctl start lxd-agent.service"
+`
 	err = os.WriteFile(filepath.Join(g.sourceDir, udevPath, "99-lxd-agent.rules"), []byte(lxdAgentRules), 0400)
 	if err != nil {
 		return fmt.Errorf("Failed to write file %q: %w", filepath.Join(g.sourceDir, udevPath, "99-lxd-agent.rules"), err)


### PR DESCRIPTION
On some systems it appears we only get an action==CHANGE event which then prevents the normal rule for action==ADD to trigger.

This separates the RUN part to be run whenever udev sees something happening with the device but keeping the symlink generation to happen only on ADD.