### PR TITLE
systemd: Make sure subshell returns success

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -708,6 +708,8 @@ fix_systemd_override_unit() {
 			[ "${systemd_version}" -ge 231 ] && echo "ReadWritePaths=";
 			[ "${systemd_version}" -ge 254 ] && echo "ImportCredential=";
 		fi
+
+		true;
 	} > "${dropin_dir}/zzz-lxc-service.conf"
 }
 


### PR DESCRIPTION
Without that older privileged containers may cause the subshell to return 1 causing the whole generator to exit due to it running under -eu.