### PR TITLE
Added rpmbootstrap source

### DIFF
--- a/managers/yum.go
+++ b/managers/yum.go
@@ -71,6 +71,12 @@ func (m *yum) load() error {
 }
 
 func (m *yum) manageRepository(repoAction shared.DefinitionPackagesRepository) error {
+	// Run rpmdb --rebuilddb
+	err := shared.RunCommand(m.ctx, nil, nil, "rpmdb", "--rebuilddb")
+	if err != nil {
+		return fmt.Errorf("failed to run rpmdb --rebuilddb: %w", err)
+	}
+
 	return yumManageRepository(repoAction)
 }
 

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -365,6 +365,7 @@ func (d *Definition) Validate() error {
 		"centos-http",
 		"springdalelinux-http",
 		"debootstrap",
+		"rpmbootstrap",
 		"fedora-http",
 		"gentoo-http",
 		"ubuntu-http",

--- a/sources/rpmbootstrap.go
+++ b/sources/rpmbootstrap.go
@@ -1,0 +1,85 @@
+package sources
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/lxc/distrobuilder/shared"
+)
+
+type rpmbootstrap struct {
+	common
+}
+
+func (s *rpmbootstrap) repodirs() (dir string, err error) {
+	// check whether yum command exists
+	if err = shared.RunCommand(s.ctx, nil, nil, "yum", "--version"); err != nil {
+		err = fmt.Errorf("yum command not found, sudo apt-get install yum to install it and try again: %w", err)
+		return
+	}
+
+	reposdir := path.Join(s.sourcesDir, "etc", "yum.repos.d")
+	err = os.MkdirAll(reposdir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	distribution := s.definition.Image.Distribution
+	content := s.definition.Source.URL
+	if distribution == "" || content == "" {
+		err = fmt.Errorf("No valid distribution and source url specified")
+		return "", err
+	}
+
+	err = os.WriteFile(path.Join(reposdir, distribution+".repo"), []byte(content), 0644)
+	if err != nil {
+		return "", err
+	}
+
+	return reposdir, nil
+}
+
+// Run runs yum --installroot.
+func (s *rpmbootstrap) Run() error {
+	repodir, err := s.repodirs()
+	if err != nil {
+		return err
+	}
+
+	release := s.definition.Image.Release
+	args := []string{fmt.Sprintf("--installroot=%s", s.rootfsDir),
+		fmt.Sprintf("--releasever=%s", release),
+		fmt.Sprintf("--setopt=reposdir=%s", repodir),
+		"install", "-y"}
+
+	os.RemoveAll(s.rootfsDir)
+	earlyPackagesRemove := s.definition.GetEarlyPackages("remove")
+
+	for _, pkg := range earlyPackagesRemove {
+		args = append(args, fmt.Sprintf("--exclude=%s", pkg))
+	}
+
+	pkgs := []string{"yum", "dnf"}
+	components := s.definition.Source.Components
+
+	for _, pkg := range components {
+		pkg, err = shared.RenderTemplate(pkg, s.definition)
+		if err != nil {
+			return err
+		}
+
+		pkgs = append(pkgs, pkg)
+	}
+
+	earlyPackagesInstall := s.definition.GetEarlyPackages("install")
+	pkgs = append(pkgs, earlyPackagesInstall...)
+	args = append(args, pkgs...)
+
+	// Install
+	if err = shared.RunCommand(s.ctx, nil, nil, "yum", args...); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sources/source.go
+++ b/sources/source.go
@@ -43,6 +43,7 @@ var downloaders = map[string]func() downloader{
 	"plamolinux-http":      func() downloader { return &plamolinux{} },
 	"rockylinux-http":      func() downloader { return &rockylinux{} },
 	"rootfs-http":          func() downloader { return &rootfs{} },
+	"rpmbootstrap":         func() downloader { return &rpmbootstrap{} },
 	"springdalelinux-http": func() downloader { return &springdalelinux{} },
 	"ubuntu-http":          func() downloader { return &ubuntu{} },
 	"voidlinux-http":       func() downloader { return &voidlinux{} },


### PR DESCRIPTION
`rpmbootstrap` source is similar with `debootstrap` source in deb package system, but it's targeted in the rpm package system. Comparing with `centos-http`, `openeuler-http` sources, it's faster with less bandwidth using.