### PR TITLE
Some fixes for 23.x OpenWRT

### DIFF
--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -31,17 +31,17 @@ func (s *openwrt) Run() error {
 	case "x86_64":
 		architecturePath = strings.Replace(s.definition.Image.ArchitectureMapped, "_", "/", 1)
 	case "armv7l":
-		if release == "snapshot" {
-			architecturePath = "armsr/armv7"
-		} else {
+		if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
 			architecturePath = "armvirt/32"
+		} else {
+			architecturePath = "armsr/armv7"
 		}
 
 	case "aarch64":
-		if release == "snapshot" {
-			architecturePath = "armsr/armv8"
-		} else {
+		if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
 			architecturePath = "armvirt/64"
+		} else {
+			architecturePath = "armsr/armv8"
 		}
 	}
 
@@ -78,25 +78,18 @@ func (s *openwrt) Run() error {
 	if release == "snapshot" {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":
-			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
-				strings.Replace(architecturePath, "/", "-", 1))
+			fallthrough
 		case "armv7l":
 			fallthrough
 		case "aarch64":
-			fname = fmt.Sprintf("openwrt-%s-rootfs.tar.gz",
+			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
 				strings.Replace(architecturePath, "/", "-", 1))
 		}
 	} else {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":
-			if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") || strings.HasPrefix(release, "23.05") {
-				fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
-					strings.Replace(architecturePath, "/", "-", 1))
-			} else {
-				fname = fmt.Sprintf("openwrt-%s%s-generic-rootfs.tar.gz", releaseInFilename,
-					strings.Replace(architecturePath, "/", "-", 1))
-			}
-
+			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
+				strings.Replace(architecturePath, "/", "-", 1))
 		case "armv7l":
 			fallthrough
 		case "aarch64":


### PR DESCRIPTION
I noticed that the jenkins build failed...

1) For x64, the original #773 should already have resulted in using the correct download link for 23.x branch. The only explanation I can think of is that the Jenkins server only had the lxc/lxc-ci#789 but not yet the distrobuilder update, causing the script to select the "*-generic*" file naming convention. Anyway, this update includes some further code cleanup since actually none of the current release generations use the -generic file naming any more.

2) For arm64, I had neglected to look through the code carefully, sorry. Specifically, the directory structure of 23.x matches that of snapshot for ARM. Since future builds will retain this, I updated the code to make this the default.