### PR TITLE
Bugfix in openwrt-http.go to handle 23.x ARM release

### DIFF
--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -85,6 +85,7 @@ func (s *openwrt) Run() error {
 		case "aarch64":
 			fname = fmt.Sprintf("openwrt-%s%s-default-rootfs.tar.gz", releaseInFilename,
 				strings.Replace(architecturePath, "/", "-", 1))
+		}
 	} else {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":

--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -75,17 +75,7 @@ func (s *openwrt) Run() error {
 
 	var fname string
 
-	if release == "snapshot" {
-		switch s.definition.Image.ArchitectureMapped {
-		case "x86_64":
-			fallthrough
-		case "armv7l":
-			fallthrough
-		case "aarch64":
-			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
-				strings.Replace(architecturePath, "/", "-", 1))
-		}
-	} else {
+	if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":
 			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
@@ -94,6 +84,15 @@ func (s *openwrt) Run() error {
 			fallthrough
 		case "aarch64":
 			fname = fmt.Sprintf("openwrt-%s%s-default-rootfs.tar.gz", releaseInFilename,
+				strings.Replace(architecturePath, "/", "-", 1))
+	} else {
+		switch s.definition.Image.ArchitectureMapped {
+		case "x86_64":
+			fallthrough
+		case "armv7l":
+			fallthrough
+		case "aarch64":
+			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,
 				strings.Replace(architecturePath, "/", "-", 1))
 		}
 	}


### PR DESCRIPTION
Somehow I got my notes on file (not just folder) naming conventions mixed up for ARM, which in 23.x matches snapshot (i.e., "default" is only for legacy, no-default naming becomes the standard now)... This should really be it now, though