### PR TITLE
Openwrt test script fix for 21-23.x branches

### DIFF
--- a/sources/openwrt-http_test.go
+++ b/sources/openwrt-http_test.go
@@ -15,12 +15,16 @@ func TestOpenWrtHTTP_getLatestServiceRelease(t *testing.T) {
 		want    *regexp.Regexp
 	}{
 		{
-			"17.01",
-			regexp.MustCompile(`17\.01\.\d+`),
+			"21.02",
+			regexp.MustCompile(`21\.02\.\d+`),
 		},
 		{
-			"18.06",
-			regexp.MustCompile(`18\.06\.\d+`),
+			"22.03",
+			regexp.MustCompile(`22\.03\.\d+`),
+		},
+		{
+			"23.05",
+			regexp.MustCompile(`23\.05\.\d+`),
 		},
 	}
 


### PR DESCRIPTION
Not that this can catch all that many errors to begin with, but non of the release branches referenced here are in use any more, so right now it's not doing anything at all. This should bring back the basic sanity check