### PR TITLE
main_validate: Set SinceErrors to true

### DIFF
--- a/distrobuilder/main_validate.go
+++ b/distrobuilder/main_validate.go
@@ -25,7 +25,8 @@ func (c *cmdValidate) command() *cobra.Command {
 
 			return nil
 		},
-		SilenceUsage: true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	c.cmdValidate.Flags().StringSliceVarP(&c.global.flagOptions, "options", "o",


### PR DESCRIPTION
If validation fails, the error message is printed twice. Setting
`SilenceErrors` to true leaves us with a single error message.
