### PR TITLE
shared/osarch: Add x86_64 to Alpine architecture map

### DIFF
--- a/shared/osarch.go
+++ b/shared/osarch.go
@@ -8,6 +8,7 @@ import (
 
 var alpineLinuxArchitectureNames = map[int]string{
 	osarch.ARCH_32BIT_INTEL_X86:           "x86",
+	osarch.ARCH_64BIT_INTEL_X86:           "x86_64",
 	osarch.ARCH_32BIT_ARMV7_LITTLE_ENDIAN: "armv7",
 }
 


### PR DESCRIPTION
This adds the missing x86_64 architecture to the Alpine Linux
architecture map.
