### PR TITLE
Replace incus.ValueInSlice with slices.Contains

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.20.x
           - 1.21.x
         os:
           - ubuntu-20.04

--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 
 	client "github.com/lxc/incus/client"
 	"github.com/lxc/incus/shared/api"
-	incus "github.com/lxc/incus/shared/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -45,7 +45,7 @@ func (c *cmdIncus) commandBuild() *cobra.Command {
 `, typeDescription, compressionDescription),
 		Args: cobra.RangeArgs(1, 2),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if !incus.ValueInSlice(c.flagType, []string{"split", "unified"}) {
+			if !slices.Contains([]string{"split", "unified"}, c.flagType) {
 				return errors.New("--type needs to be one of ['split', 'unified']")
 			}
 
@@ -113,7 +113,7 @@ func (c *cmdIncus) commandPack() *cobra.Command {
 `, typeDescription, compressionDescription),
 		Args: cobra.RangeArgs(2, 3),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if !incus.ValueInSlice(c.flagType, []string{"split", "unified"}) {
+			if !slices.Contains([]string{"split", "unified"}, c.flagType) {
 				return errors.New("--type needs to be one of ['split', 'unified']")
 			}
 

--- a/distrobuilder/main_repack-windows.go
+++ b/distrobuilder/main_repack-windows.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -110,7 +111,7 @@ func (c *cmdRepackWindows) preRun(cmd *cobra.Command, args []string) error {
 	} else {
 		supportedVersions := []string{"w11", "w10", "2k19", "2k12", "2k16", "2k22"}
 
-		if !incus.ValueInSlice(c.flagWindowsVersion, supportedVersions) {
+		if !slices.Contains(supportedVersions, c.flagWindowsVersion) {
 			return fmt.Errorf("Version must be one of %v", supportedVersions)
 		}
 	}
@@ -126,7 +127,7 @@ func (c *cmdRepackWindows) preRun(cmd *cobra.Command, args []string) error {
 	} else {
 		supportedArchitectures := []string{"amd64", "ARM64"}
 
-		if !incus.ValueInSlice(c.flagWindowsArchitecture, supportedArchitectures) {
+		if !slices.Contains(supportedArchitectures, c.flagWindowsArchitecture) {
 			return fmt.Errorf("Architecture must be one of %v", supportedArchitectures)
 		}
 	}
@@ -554,7 +555,7 @@ func (c *cmdRepackWindows) injectDrivers(dirs map[string]string) error {
 			targetPath := filepath.Join(targetBasePath, filepath.Base(path))
 
 			// Copy driver files
-			if incus.ValueInSlice(ext, []string{".cat", ".dll", ".inf", ".sys"}) {
+			if slices.Contains([]string{".cat", ".dll", ".inf", ".sys"}, ext) {
 				logger.WithFields(logrus.Fields{"src": path, "dest": targetPath}).Debug("Copying file")
 
 				err := shared.Copy(path, targetPath)

--- a/distrobuilder/vm.go
+++ b/distrobuilder/vm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -29,7 +30,7 @@ func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64) (*
 		fs = "ext4"
 	}
 
-	if !incus.ValueInSlice(fs, []string{"btrfs", "ext4"}) {
+	if !slices.Contains([]string{"btrfs", "ext4"}, fs) {
 		return nil, fmt.Errorf("Unsupported fs: %s", fs)
 	}
 

--- a/generators/cloud-init.go
+++ b/generators/cloud-init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/lxc/incus/shared/api"
@@ -29,7 +30,7 @@ func (g *cloudInit) RunLXC(img *image.LXCImage, target shared.DefinitionTargetLX
 				return nil
 			}
 
-			if incus.ValueInSlice(info.Name(), []string{"cloud-init-local", "cloud-config", "cloud-init", "cloud-final"}) {
+			if slices.Contains([]string{"cloud-init-local", "cloud-config", "cloud-init", "cloud-final"}, info.Name()) {
 				err := os.Remove(path)
 				if err != nil {
 					return fmt.Errorf("Failed to remove file %q: %w", path, err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/lxc/distrobuilder
 
-go 1.18
+go 1.21.0
+
+toolchain go1.21.3
 
 exclude (
 	github.com/rootless-containers/proto v0.1.0

--- a/managers/pacman.go
+++ b/managers/pacman.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-
-	incus "github.com/lxc/incus/shared/util"
+	"slices"
 
 	"github.com/lxc/distrobuilder/shared"
 )
@@ -100,7 +99,7 @@ func (m *pacman) setupTrustedKeys() error {
 
 	var keyring string
 
-	if incus.ValueInSlice(runtime.GOARCH, []string{"arm", "arm64"}) {
+	if slices.Contains([]string{"arm", "arm64"}, runtime.GOARCH) {
 		keyring = "archlinuxarm"
 	} else {
 		keyring = "archlinux"
@@ -124,7 +123,7 @@ func (m *pacman) setMirrorlist() error {
 
 	var mirror string
 
-	if incus.ValueInSlice(runtime.GOARCH, []string{"arm", "arm64"}) {
+	if slices.Contains([]string{"arm", "arm64"}, runtime.GOARCH) {
 		mirror = "Server = http://mirror.archlinuxarm.org/$arch/$repo"
 	} else {
 		mirror = "Server = http://mirrors.kernel.org/archlinux/$repo/os/$arch"

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	incus "github.com/lxc/incus/shared/util"
@@ -24,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && incus.ValueInSlice(release, []string{"xenial", "bionic"}) || distro == "mint" && incus.ValueInSlice(release, []string{"tara", "tessa", "tina", "tricia", "ulyana"}) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")

--- a/sources/plamolinux-http.go
+++ b/sources/plamolinux-http.go
@@ -6,10 +6,10 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
-	incus "github.com/lxc/incus/shared/util"
 	"gopkg.in/antchfx/htmlquery.v1"
 
 	"github.com/lxc/distrobuilder/shared"
@@ -152,7 +152,7 @@ func (s *plamolinux) downloadFiles(def shared.DefinitionImage, URL string, ignor
 
 		if strings.HasSuffix(target, ".txz") || strings.HasSuffix(target, ".tzst") {
 			pkgName := strings.Split(target, "-")[0]
-			if incus.ValueInSlice(pkgName, ignoredPkgs) {
+			if slices.Contains(ignoredPkgs, pkgName) {
 				continue
 			}
 

--- a/sources/slackware-http.go
+++ b/sources/slackware-http.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
-	incus "github.com/lxc/incus/shared/util"
 	"gopkg.in/antchfx/htmlquery.v1"
 
 	"github.com/lxc/distrobuilder/shared"
@@ -150,7 +150,7 @@ func (s *slackware) downloadFiles(def shared.DefinitionImage, URL string, requir
 			pkgName := strings.Split(target, "-")[0]
 			twoPkgName := strings.Split(target, "-")[0] + "-" + strings.Split(target, "-")[1]
 
-			if !((incus.ValueInSlice(pkgName, requiredPkgs)) || (incus.ValueInSlice(twoPkgName, requiredPkgs))) {
+			if !((slices.Contains(requiredPkgs, pkgName)) || (slices.Contains(requiredPkgs, twoPkgName))) {
 				continue
 			}
 


### PR DESCRIPTION
This replaces `incus.ValueInSlice` with `slices.Contains` which was introduced in Go 1.21.0.
