### PR TITLE
main: Add missing `--sources-dir` to `build-incus` command

### DIFF
--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -96,6 +96,7 @@ func (c *cmdIncus) commandBuild() *cobra.Command {
 	c.cmdBuild.Flags().BoolVar(&c.flagVM, "vm", false, "Create a qcow2 image for VMs"+"``")
 	c.cmdBuild.Flags().StringVar(&c.flagImportIntoIncus, "import-into-incus", "", "Import built image into Incus"+"``")
 	c.cmdBuild.Flags().BoolVar(&c.global.flagKeepSources, "keep-sources", true, "Keep sources after build"+"``")
+	c.cmdBuild.Flags().StringVar(&c.global.flagSourcesDir, "sources-dir", filepath.Join(os.TempDir(), "distrobuilder"), "Sources directory for distribution tarballs"+"``")
 
 	return c.cmdBuild
 }


### PR DESCRIPTION
This adds the missing `--sources-dir` flag to the `build-incus`
subcommand.

Fixes #802
