### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ NOTE: Distrobuilder requires Go 1.20 or higher, if your distribution doesn't hav
 Second, download the source code of the `distrobuilder` repository (this repository).
 
 ```
+mkdir -p $HOME/go/src/github.com/lxc/
+cd $HOME/go/src/github.com/lxc/
 git clone https://github.com/lxc/distrobuilder
 ```
 


### PR DESCRIPTION
This directory structure is required so that the following line

cp $HOME/go/src/github.com/lxc/distrobuilder/doc/examples/ubuntu.yaml ubuntu.yaml

works in the following tutorial

https://linuxcontainers.org/distrobuilder/docs/latest/tutorials/use/

I had to hunt around to find the example YAML configuration files.