### PR TITLE
Remove race in tests

### DIFF
--- a/generators/cloud-init_test.go
+++ b/generators/cloud-init_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func TestCloudInitGeneratorRunLXC(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)
@@ -63,7 +65,9 @@ func TestCloudInitGeneratorRunLXC(t *testing.T) {
 }
 
 func TestCloudInitGeneratorRunIncus(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)

--- a/generators/copy_test.go
+++ b/generators/copy_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestCopyGeneratorRun(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)

--- a/generators/dump_test.go
+++ b/generators/dump_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestDumpGeneratorRunLXC(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)
@@ -78,7 +80,9 @@ func TestDumpGeneratorRunLXC(t *testing.T) {
 }
 
 func TestDumpGeneratorRunIncus(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)

--- a/generators/hostname_test.go
+++ b/generators/hostname_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestHostnameGeneratorRunLXC(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)
@@ -44,7 +46,9 @@ func TestHostnameGeneratorRunLXC(t *testing.T) {
 }
 
 func TestHostnameGeneratorRunIncus(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)

--- a/generators/hosts_test.go
+++ b/generators/hosts_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestHostsGeneratorRunLXC(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)
@@ -46,7 +48,9 @@ func TestHostsGeneratorRunLXC(t *testing.T) {
 }
 
 func TestHostsGeneratorRunIncus(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)

--- a/generators/template_test.go
+++ b/generators/template_test.go
@@ -13,7 +13,9 @@ import (
 )
 
 func TestTemplateGeneratorRunIncus(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)
@@ -50,7 +52,9 @@ func TestTemplateGeneratorRunIncus(t *testing.T) {
 }
 
 func TestTemplateGeneratorRunIncusDefaultWhen(t *testing.T) {
-	cacheDir := filepath.Join(os.TempDir(), "distrobuilder-test")
+	cacheDir, err := os.MkdirTemp(os.TempDir(), "distrobuilder-test-")
+	require.NoError(t, err)
+
 	rootfsDir := filepath.Join(cacheDir, "rootfs")
 
 	setup(t, cacheDir)


### PR DESCRIPTION
This makes use of `os.MkdirTemp` in order to avoid race issues when
running the tests in parallel.

Closes #818
