### PR TITLE
Fixed hardcoded root partition device name sda2

### DIFF
--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -352,6 +353,13 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
 			return fmt.Errorf("Failed to mount UEFI partition: %w", err)
 		}
 
+		rootUUID, err := vm.findRootfsDevUUID()
+		if err != nil {
+			return fmt.Errorf("Failed to find rootfs device UUID: %w", err)
+		}
+
+		c.global.ctx = context.WithValue(c.global.ctx, shared.ContextKeyEnviron,
+			[]string{fmt.Sprintf("%s=%s", shared.EnvRootUUID, rootUUID)})
 		// We cannot use Incus' rsync package as that uses the --delete flag which
 		// causes an issue due to the boot/efi directory being present.
 		err = shared.RsyncLocal(c.global.ctx, overlayDir+"/", vmDir)

--- a/shared/util.go
+++ b/shared/util.go
@@ -18,6 +18,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	ContextKeyEnviron = ContextKey("environ")
+	EnvRootUUID       = "DISTROBUILDER_ROOT_UUID"
+)
+
 // EnvVariable represents a environment variable.
 type EnvVariable struct {
 	Value string
@@ -26,6 +31,9 @@ type EnvVariable struct {
 
 // Environment represents a set of environment variables.
 type Environment map[string]EnvVariable
+
+// ContextKey type.
+type ContextKey string
 
 // Copy copies a file.
 func Copy(src, dest string) error {
@@ -56,6 +64,10 @@ func Copy(src, dest string) error {
 // RunCommand runs a command. Stdout is written to the given io.Writer. If nil, it's written to the real stdout. Stderr is always written to the real stderr.
 func RunCommand(ctx context.Context, stdin io.Reader, stdout io.Writer, name string, arg ...string) error {
 	cmd := exec.CommandContext(ctx, name, arg...)
+	env, ok := ctx.Value(ContextKeyEnviron).([]string)
+	if ok && len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 
 	if stdin != nil {
 		cmd.Stdin = stdin


### PR DESCRIPTION
The root partition may not be /dev/sda2, for example if set the boot disk as the second disk, the root partition device name will be /dev/sdb2. It may be /dev/vda2 if not using san disk. The fix figured out the root partition device UUID and set the UUID as the root, the root partition device UUID keeps no change.