### PR TITLE
Make run-parts running compatible with different versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,4 @@ ifeq ($(shell command -v golangci-lint 2> /dev/null),)
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
 endif
 	golangci-lint run --timeout 5m
-	run-parts --exit-on-error --regex '.sh' test/lint
+	run-parts $(shell run-parts -V 2> /dev/null 1> /dev/null && echo -n "--exit-on-error --regex '.sh'") test/lint


### PR DESCRIPTION
The option `--exit-on-error' exists only on debian run-parts version. On centos, redhat or federa, run-parts has no such option.

The fix checks version and adds options accordingly.