### PR TITLE
Update actions.md

### DIFF
--- a/doc/reference/actions.md
+++ b/doc/reference/actions.md
@@ -31,4 +31,5 @@ For more on `packages`, see [packages](packages.md).
 
 And last, after the `files` section has been processed, all `post-files` actions are run.
 This action runs only for `build-lxc`, `build-incus`, `pack-lxc`, and `pack-incus`.
+You can also force enable post-files for `build-dir` with option `--with-post-files`
 For more on `files`, see [generators](generators.md).


### PR DESCRIPTION
Add flag --with-post-file

By default, build-dir didn't execute `post-files` hook.
In case the developer needs this hook. They can enable by the command line flag `--with-post-files`

```
distrobuilder \
        build-dir \
            --with-post-files \
            ubuntu.yaml rootfs
```

This PR update the document for this option, which didn't mention on any page of current document