### PR TITLE
systemd v256 seems to require overriding ImportCredential= for all containers

### DIFF
--- a/distrobuilder/lxc.generator
+++ b/distrobuilder/lxc.generator
@@ -92,6 +92,7 @@ fix_systemd_override_unit() {
 		[ "${systemd_version}" -ge 239 ] && echo "NoNewPrivileges=no";
 		[ "${systemd_version}" -ge 249 ] && echo "LoadCredential=";
 		[ "${systemd_version}" -ge 254 ] && echo "PrivateNetwork=no";
+		[ "${systemd_version}" -ge 256 ] && echo "ImportCredential=";
 
 		# Additional settings for privileged containers
 		if is_lxc_privileged_container; then
@@ -102,7 +103,7 @@ fix_systemd_override_unit() {
 			[ "${systemd_version}" -ge 244 ] && echo "ProtectKernelLogs=no";
 			[ "${systemd_version}" -ge 232 ] && echo "ProtectKernelModules=no";
 			[ "${systemd_version}" -ge 231 ] && echo "ReadWritePaths=";
-			[ "${systemd_version}" -ge 254 ] && echo "ImportCredential=";
+			[ "${systemd_version}" -ge 254 ] && [ "${systemd_version}" -lt 256 ] && echo "ImportCredential=";
 		fi
 
 		true;


### PR DESCRIPTION
After #849, privileged Debian sid containers with systemd v256~rc3 work fine, but unprivileged ones don't. Adding the `ImportCredential=` override for them as well finally makes all my sid containers happy again.