### PR TITLE
distrobuilder: Remove LXD support

### DIFF
--- a/.sphinx/wordlist.txt
+++ b/.sphinx/wordlist.txt
@@ -118,8 +118,6 @@ LV
 LVM
 LXC
 LXCFS
-LXD
-LXD's
 MAAS
 macOS
 macvlan

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # distrobuilder
 System container and VM image builder for Incus and LXC.
 
-Incus images may also be compatible with Canonical's LXD.
-
 ## Status
 Type            | Service               | Status
 ---             | ---                   | ---

--- a/distrobuilder/lxc.generator
+++ b/distrobuilder/lxc.generator
@@ -16,11 +16,6 @@ is_lxc_privileged_container() {
 	grep -qw 4294967295$ /proc/self/uid_map
 }
 
-# is_lxd_vm succeeds if we're running inside a LXD VM
-is_lxd_vm() {
-	[ -e /dev/virtio-ports/org.linuxcontainers.lxd ]
-}
-
 # is_incus_vm succeeds if we're running inside an Incus VM
 is_incus_vm() {
 	[ -e /dev/virtio-ports/org.linuxcontainers.incus ]
@@ -154,7 +149,7 @@ fix_systemd_sysctl() {
 
 ## Main logic
 # Nothing to do in Incus VM but deployed in case it is later converted to a container
-is_incus_vm || is_lxd_vm && exit 0
+is_incus_vm && exit 0
 
 # Exit immediately if not an Incus/LXC container
 is_lxc_container || exit 0

--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -375,7 +375,7 @@ func (c *cmdGlobal) preRunBuild(cmd *cobra.Command, args []string) error {
 	case "build-lxc":
 		// If we're running build-lxc, also process container-only sections.
 		imageTargets |= shared.ImageTargetContainer
-	case "build-incus", "build-lxd":
+	case "build-incus":
 		// Include either container-specific or vm-specific sections when
 		// running build-incus.
 		ok, err := cmd.Flags().GetBool("vm")

--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -35,9 +35,8 @@ type cmdIncus struct {
 
 func (c *cmdIncus) commandBuild() *cobra.Command {
 	c.cmdBuild = &cobra.Command{
-		Use:     "build-incus <filename|-> [target dir] [--type=TYPE] [--compression=COMPRESSION] [--import-into-incus]",
-		Aliases: []string{"build-lxd"},
-		Short:   "Build Incus image from scratch",
+		Use:   "build-incus <filename|-> [target dir] [--type=TYPE] [--compression=COMPRESSION] [--import-into-incus]",
+		Short: "Build Incus image from scratch",
 		Long: fmt.Sprintf(`Build Incus image from scratch
 
 %s
@@ -104,9 +103,8 @@ func (c *cmdIncus) commandBuild() *cobra.Command {
 
 func (c *cmdIncus) commandPack() *cobra.Command {
 	c.cmdPack = &cobra.Command{
-		Use:     "pack-incus <filename|-> <source dir> [target dir] [--type=TYPE] [--compression=COMPRESSION] [--import-into-incus]",
-		Aliases: []string{"pack-lxd"},
-		Short:   "Create Incus image from existing rootfs",
+		Use:   "pack-incus <filename|-> <source dir> [target dir] [--type=TYPE] [--compression=COMPRESSION] [--import-into-incus]",
+		Short: "Create Incus image from existing rootfs",
 		Long: fmt.Sprintf(`Create Incus image from existing rootfs
 
 %s

--- a/doc/tutorials/use.md
+++ b/doc/tutorials/use.md
@@ -1,7 +1,3 @@
----
-discourse: 7519
----
-
 # Use `distrobuilder` to create images
 
 This guide shows you how to create an image for Incus or LXC.
@@ -156,9 +152,6 @@ lxc-start -n myContainerImage
 ```
 
 ## Repack Windows ISO
-
-```{youtube} https://www.youtube.com/watch?v=3PDMGwbbk48
-```
 
 With Incus it's possible to run Windows VMs. All you need is a Windows ISO and a bunch of drivers.
 To make the installation a bit easier, `distrobuilder` added the `repack-windows` command. It takes a Windows ISO, and repacks it together with the necessary drivers.

--- a/generators/generators.go
+++ b/generators/generators.go
@@ -38,9 +38,6 @@ var generators = map[string]func() generator{
 	"incus-agent": func() generator { return &incusAgent{} },
 	"remove":      func() generator { return &remove{} },
 	"template":    func() generator { return &template{} },
-
-	// Legacy.
-	"lxd-agent": func() generator { return &incusAgent{} },
 }
 
 // Load loads and initializes a generator.

--- a/generators/incus-agent.go
+++ b/generators/incus-agent.go
@@ -72,11 +72,6 @@ eject "${CDROM}" >/dev/null 2>&1 || true
 # Fix up permissions.
 chown -R root:root "${PREFIX}"
 
-# Legacy.
-if [ ! -e "${PREFIX}/incus-agent" ] && [ -e "${PREFIX}/lxd-agent" ]; then
-    ln -s lxd-agent "${PREFIX}"/incus-agent
-fi
-
 # Attempt to restore SELinux labels.
 restorecon -R "${PREFIX}" >/dev/null 2>&1 || true
 
@@ -170,9 +165,6 @@ StartLimitBurst=10
 	}
 
 	incusAgentRules := `SYMLINK=="virtio-ports/org.linuxcontainers.incus", TAG+="systemd", ENV{SYSTEMD_WANTS}+="incus-agent.service"
-
-# Legacy.
-SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="incus-agent.service"
 `
 	err = os.WriteFile(filepath.Join(g.sourceDir, udevPath, "99-incus-agent.rules"), []byte(incusAgentRules), 0400)
 	if err != nil {


### PR DESCRIPTION
As the transition period for the image server has now expired, there's no point in keeping around this untested logic.