### PR TITLE
Fixed multiple sys files not copied issue

### DIFF
--- a/distrobuilder/main_repack-windows.go
+++ b/distrobuilder/main_repack-windows.go
@@ -481,25 +481,29 @@ func (c *cmdRepackWindows) injectDrivers(infDir, driversDir, filerepositoryDir, 
 		}
 
 		for ext, dir := range map[string]string{"inf": infDir, "cat": driversDir, "dll": driversDir, "sys": driversDir} {
-			driverPath, err := shared.FindFirstMatch(sourceDir, fmt.Sprintf("*.%s", ext))
+			sourceMatches, err := shared.FindAllMatches(sourceDir, fmt.Sprintf("*.%s", ext))
 			if err != nil {
 				logger.Debugf("failed to find first match %q %q", driverName, ext)
 				continue
 			}
 
-			targetName := filepath.Base(driverPath)
-			if err = shared.Copy(driverPath, filepath.Join(targetBaseDir, targetName)); err != nil {
-				return err
-			}
+			for _, sourcePath := range sourceMatches {
+				targetName := filepath.Base(sourcePath)
+				targetPath := filepath.Join(targetBaseDir, targetName)
+				if err = shared.Copy(sourcePath, targetPath); err != nil {
+					return err
+				}
 
-			if ext == "cat" {
-				continue
-			} else if ext == "inf" {
-				targetName = infFilename
-			}
+				if ext == "cat" {
+					continue
+				} else if ext == "inf" {
+					targetName = infFilename
+				}
 
-			if err = shared.Copy(driverPath, filepath.Join(dir, targetName)); err != nil {
-				return err
+				targetPath = filepath.Join(dir, targetName)
+				if err = shared.Copy(sourcePath, targetPath); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -63,15 +63,26 @@ func CaseInsensitive(s string) (pattern string) {
 	return
 }
 
-// FindFirstMatch find the first file case insensitive.
+// FindFirstMatch find the first matched file case insensitive.
 func FindFirstMatch(dir string, elem ...string) (found string, err error) {
+	matches, err := FindAllMatches(dir, elem...)
+	if err != nil {
+		return
+	}
+
+	found = matches[0]
+	return
+}
+
+// FindAllMatches find all the matched files case insensitive.
+func FindAllMatches(dir string, elem ...string) (matches []string, err error) {
 	names := []string{dir}
 	for _, name := range elem {
 		names = append(names, CaseInsensitive(name))
 	}
 
 	pattern := filepath.Join(names...)
-	matches, err := filepath.Glob(pattern)
+	matches, err = filepath.Glob(pattern)
 	if err != nil {
 		return
 	}
@@ -81,7 +92,6 @@ func FindFirstMatch(dir string, elem ...string) (found string, err error) {
 		return
 	}
 
-	found = matches[0]
 	return
 }
 


### PR DESCRIPTION
Driver like vioinput has multiple sys files `viohidkmdf.sys` and `vioinput.sys`, without `vioinput.sys` copied, the vioinput driver not work correctly.

The fix add the multiple files copied back.