### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To compile `distrobuilder` from source, first install the Go programming languag
 
 - Red Hat-based:
     ```
-    sudo dnf update
+	sudo dnf check-update
     sudo dnf install golang debootstrap rsync gnupg2 squashfs-tools git make
     ```
 


### PR DESCRIPTION
`dnf update` equivalents to `apt install --only-upgrade` so changed it to `dnf check-update` the rarely used command since usually package cache automatically updated.