### PR TITLE
Keep incus-agent org.linuxcontainers.lxd compatible support

### DIFF
--- a/doc/examples/ubuntu.yaml
+++ b/doc/examples/ubuntu.yaml
@@ -326,5 +326,14 @@ actions:
   types:
   - vm
 
+- trigger: post-files
+  action: |-
+    #!/bin/sh
+    set -eux
+    sed -e '/^# Unmount.*/i [ -x "${PREFIX}"/incus-agent ] || ln -s "${PREFIX}"/*-agent "${PREFIX}"/incus-agent\n' -i /usr/lib/systemd/incus-agent-setup
+    sed -e 's/org.linuxcontainers.incus/org.linuxcontainers.*/g' -i /usr/lib/udev/rules.d/99-incus-agent.rules
+  types:
+  - vm
+
 mappings:
   architecture_map: debian


### PR DESCRIPTION
This PR is used to show how to support `org.linuxcontainers.lxd` in build yaml file. It shows:
1. It's possible to support `org.linuxcontainers.lxd` even if `incus-agent` not,
2. How urgly it is to add the support in build yaml.