### PR TITLE
debootstrap: Remove no-merged-usr/merged-usr logic

### DIFF
--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	incus "github.com/lxc/incus/v6/shared/util"
@@ -20,16 +19,6 @@ type debootstrap struct {
 // Run runs debootstrap.
 func (s *debootstrap) Run() error {
 	var args []string
-
-	distro := strings.ToLower(s.definition.Image.Distribution)
-	release := strings.ToLower(s.definition.Image.Release)
-
-	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic", "noble"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
-		args = append(args, "--no-merged-usr")
-	} else {
-		args = append(args, "--merged-usr")
-	}
 
 	os.RemoveAll(s.rootfsDir)
 


### PR DESCRIPTION
This logic is confusing/outdated and newer debootstrap should be able to cope out of the box. So let's remove it for now and we'll add back specific exceptions if needed.