### PR TITLE
opensuse: Temporarily switch to mirrorcache-eu to fix downloads

### DIFF
--- a/sources/opensuse-http.go
+++ b/sources/opensuse-http.go
@@ -29,7 +29,7 @@ func (s *opensuse) Run() error {
 	var fname string
 
 	if s.definition.Source.URL == "" {
-		s.definition.Source.URL = "https://mirrorcache-us.opensuse.org/download"
+		s.definition.Source.URL = "https://mirrorcache-eu.opensuse.org/download"
 	}
 
 	tarballPath, err := s.getPathToTarball(s.definition.Source.URL, s.definition.Image.Release,


### PR DESCRIPTION
According to https://status.opensuse.org, mirrorcache-us.opensuse.org has been down for maintenance for 15 days. mirrorcache-eu.opensuse.org is still up, so switch temporarily to fix distrobuilder downloads.