### PR TITLE
nixos: correctly handle 24.11

### DIFF
--- a/sources/nixos-http.go
+++ b/sources/nixos-http.go
@@ -15,13 +15,16 @@ func (s *nixos) Run() error {
 	hydraProject := "nixos"
 
 	hydraJobset := fmt.Sprintf("release-%s", s.definition.Image.Release)
-	releaseAttr := "lxdContainerImage"
-	hydraBuildProduct := "system-tarball"
+	releaseAttr := "incusContainerImage"
+	hydraBuildProduct := "squashfs-image"
+
+	if s.definition.Image.Release == "24.05" {
+		releaseAttr = "lxdContainerImage"
+		hydraBuildProduct = "system-tarball"
+	}
 
 	if s.definition.Image.Release == "unstable" {
 		hydraJobset = "trunk-combined"
-		releaseAttr = "incusContainerImage"
-		hydraBuildProduct = "squashfs-image"
 	}
 
 	hydraJob := fmt.Sprintf("nixos.%s.%s-linux", releaseAttr, s.definition.Image.ArchitectureMapped)


### PR DESCRIPTION
Not quite ready to remove 24.05, but 24.11 and moving forward is an Incus specific image. Should have written it this way to begin with, but oh well. :)