### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To compile `distrobuilder` from source, first install the Go programming languag
 - Debian-based:
     ```
     sudo apt update
-    sudo apt install -y golang-go debootstrap rsync gpg squashfs-tools git make
+    sudo apt install -y golang-go debootstrap rsync gpg squashfs-tools git make build-essential
     ```
 
 - ArchLinux-based:


### PR DESCRIPTION
For Debian-based systems, build-essential is required to build distrobuilder. I'm not sure of similar dependencies for ArchLinux-based systems or Red Hat-based systems, but those will need updated too