### PR TITLE
systemd: Relax read-only path workaround

### DIFF
--- a/distrobuilder/lxc.generator
+++ b/distrobuilder/lxc.generator
@@ -38,7 +38,7 @@ fix_ro_paths() {
 	cat <<-EOF > "/run/systemd/system/$1.d/zzz-lxc-ropath.conf"
 		# This file was created by distrobuilder
 		[Service]
-		BindReadOnlyPaths=/sys /proc
+		BindReadOnlyPaths=/sys
 		EOF
 }
 


### PR DESCRIPTION
Making /proc/sys read-only prevents networkd from changing some sysctls, let's see if just making /sys read-only is enough to keep things behaving.

Closes: https://github.com/lxc/incus/issues/1574