### PR TITLE
Update OpenWRT to support v24.10 (and drop v21.x)

### DIFF
--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -29,16 +29,16 @@ func (s *openwrt) Run() error {
 
 	switch s.definition.Image.ArchitectureMapped {
 	case "x86_64":
-		architecturePath = strings.Replace(s.definition.Image.ArchitectureMapped, "_", "/", 1)
+		architecturePath = "x86/64"
 	case "armv7l":
-		if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
+		if strings.HasPrefix(release, "22.03") {
 			architecturePath = "armvirt/32"
 		} else {
 			architecturePath = "armsr/armv7"
 		}
 
 	case "aarch64":
-		if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
+		if strings.HasPrefix(release, "22.03") {
 			architecturePath = "armvirt/64"
 		} else {
 			architecturePath = "armsr/armv8"
@@ -75,7 +75,7 @@ func (s *openwrt) Run() error {
 
 	var fname string
 
-	if strings.HasPrefix(release, "21.02") || strings.HasPrefix(release, "22.03") {
+	if strings.HasPrefix(release, "22.03") {
 		switch s.definition.Image.ArchitectureMapped {
 		case "x86_64":
 			fname = fmt.Sprintf("openwrt-%s%s-rootfs.tar.gz", releaseInFilename,

--- a/sources/openwrt-http_test.go
+++ b/sources/openwrt-http_test.go
@@ -15,16 +15,16 @@ func TestOpenWrtHTTP_getLatestServiceRelease(t *testing.T) {
 		want    *regexp.Regexp
 	}{
 		{
-			"21.02",
-			regexp.MustCompile(`21\.02\.\d+`),
-		},
-		{
 			"22.03",
 			regexp.MustCompile(`22\.03\.\d+`),
 		},
 		{
 			"23.05",
 			regexp.MustCompile(`23\.05\.\d+`),
+		},
+		{
+			"24.10",
+			regexp.MustCompile(`24\.10\.\d+`),
 		},
 	}
 


### PR DESCRIPTION
Not much to add beyond title; concurrent commit in lxc-ci also available lxc/lxc-ci#870