### PR TITLE
Update builds.yml to v4 artifact actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: doc/html


### PR DESCRIPTION
upload-artifact@v3 deprecated as of Jan 30. May require additional code updates elsewhere, though?