### PR TITLE
Change naming of infFilename to be deterministic

### DIFF
--- a/windows/repack_util.go
+++ b/windows/repack_util.go
@@ -81,14 +81,12 @@ func (r *RepackUtil) InjectDrivers(windowsRootPath string, driverPath string) er
 
 	logger := r.logger
 
-	i := 0
-
 	driversRegistry := "Windows Registry Editor Version 5.00"
 	systemRegistry := "Windows Registry Editor Version 5.00"
 	softwareRegistry := "Windows Registry Editor Version 5.00"
 	for driverName, driverInfo := range Drivers {
 		logger.WithField("driver", driverName).Debug("Injecting driver")
-		infFilename := fmt.Sprintf("oem-virtio-incus%d.inf", i)
+		infFilename := strings.ToLower(driverName) + ".inf"
 		sourceDir := filepath.Join(driverPath, driverName, r.windowsVersion, r.windowsArchitecture)
 		targetBaseDir := filepath.Join(dirs["filerepository"], driverInfo.PackageName)
 		if !incus.PathExists(targetBaseDir) {
@@ -182,8 +180,6 @@ func (r *RepackUtil) InjectDrivers(windowsRootPath string, driverPath string) er
 
 			softwareRegistry = fmt.Sprintf("%s\n\n%s", softwareRegistry, out)
 		}
-
-		i++
 	}
 
 	logger.WithField("hivefile", "DRIVERS").Debug("Updating Windows registry")


### PR DESCRIPTION
Currently `infFilename `for each driver gets named like "oem-virtio-incus3.inf".
Problem with this setup is that the names dont tell us what driver it is and the number changes randomly on each run of Distrobuilder because output of `map` in Golang is in random order.
So run it once and `vioscsi `gets `infFilename = "oem-virtio-incus3.inf"` for example.
Run it again ang it gets `infFilename = "oem-virtio-incus5.inf"`

This is bad for debugging because you can never know which `infFilename` belongs to which driver.
On disk it looks like this:
![image](https://github.com/user-attachments/assets/db38b6c7-5797-4249-8eaa-0d104b659711)
`infFilename ` is also used in Windows Registry where its also confusing.

This pull request changes the naming to be the same as driver `driverName` but lowercase.

If you prefer it can be also something like this. Maybe to avoid potential naming conflicts?
`infFilename := "oem-virtio-" + strings.ToLower(driverName) + ".inf"`

Important thing is for it to be always the same and contain name of the actual driver.

Thanks.