### PR TITLE
sources: Add Alpaquita downloader

### DIFF
--- a/doc/reference/source.md
+++ b/doc/reference/source.md
@@ -19,6 +19,7 @@ source:
 The `downloader` field defines a downloader which pulls a rootfs image which will be used as a starting point.
 It needs to be one of
 
+* `alpaquita-http`
 * `alpinelinux-http`
 * `alt-http`
 * `apertis-http`
@@ -52,6 +53,7 @@ The `keyserver` defaults to `hkps.pool.sks-keyservers.net` if none is provided.
 The `variant` field is only used in a few distributions and defaults to `default`.
 Here's a list downloaders and their possible variants:
 
+* `alpaquita-http`: `musl`, `glibc`
 * `centos-http`: `minimal`, `netinstall`, `LiveDVD`
 * `debootstrap`: `default`, `minbase`, `buildd`, `fakechroot`
 * `ubuntu-http`: `default`, `core`

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -358,6 +358,7 @@ func (d *Definition) Validate() error {
 
 	validDownloaders := []string{
 		"almalinux-http",
+		"alpaquita-http",
 		"alpinelinux-http",
 		"alt-http",
 		"apertis-http",

--- a/sources/alpaquita-http.go
+++ b/sources/alpaquita-http.go
@@ -1,0 +1,75 @@
+package sources
+
+import (
+	"crypto/sha512"
+	"fmt"
+	"path/filepath"
+
+	"github.com/lxc/distrobuilder/shared"
+)
+
+type alpaquita struct {
+	common
+}
+
+func (s *alpaquita) Run() error {
+	baseURL, fname, err := s.getMiniroot(s.definition)
+	if err != nil {
+		return err
+	}
+
+	var fpath string
+	tarballURL := baseURL + fname
+	if s.definition.Source.SkipVerification {
+		fpath, err = s.DownloadHash(s.definition.Image,
+			tarballURL, "", nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		fpath, err = s.DownloadHash(s.definition.Image,
+			tarballURL, tarballURL+".sha512", sha512.New())
+		if err != nil {
+			return err
+		}
+	}
+
+	tarballLocal := filepath.Join(fpath, fname)
+	s.logger.WithField("file", tarballLocal).Info("Unpacking image")
+
+	err = shared.Unpack(tarballLocal, s.rootfsDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Sample URLs (or with "latest" instead of date):
+//
+//	https://packages.bell-sw.com/alpaquita/musl/stream/releases/x86_64/alpaquita-minirootfs-stream-241231-musl-x86_64.tar.gz
+//	https://packages.bell-sw.com/alpaquita/glibc/23/releases/aarch64/alpaquita-minirootfs-23-241231-glibc-aarch64.tar.gz
+func (s *alpaquita) getMiniroot(definition shared.Definition) (string, string, error) {
+	// default server
+	if s.definition.Source.URL == "" {
+		s.definition.Source.URL = "https://packages.bell-sw.com"
+	}
+
+	// require explicit variant
+	if s.definition.Image.Variant == "default" {
+		return "", "", fmt.Errorf("Alpaquita requires explicitly specified variant")
+	}
+
+	base := fmt.Sprintf("%s/alpaquita/%s/%s/releases/%s/",
+		s.definition.Source.URL,
+		s.definition.Image.Variant,
+		s.definition.Image.Release,
+		s.definition.Image.ArchitectureMapped)
+
+	fname := fmt.Sprintf("alpaquita-minirootfs-%s-latest-%s-%s.tar.gz",
+		s.definition.Image.Release,
+		s.definition.Image.Variant,
+		s.definition.Image.ArchitectureMapped)
+
+	return base, fname, nil
+}

--- a/sources/source.go
+++ b/sources/source.go
@@ -25,6 +25,7 @@ type Downloader interface {
 
 var downloaders = map[string]func() downloader{
 	"almalinux-http":       func() downloader { return &almalinux{} },
+	"alpaquita-http":       func() downloader { return &alpaquita{} },
 	"alpinelinux-http":     func() downloader { return &alpineLinux{} },
 	"alt-http":             func() downloader { return &altLinux{} },
 	"apertis-http":         func() downloader { return &apertis{} },


### PR DESCRIPTION
This PR adds miniroot downloader for Alpaquita Linux, a trimmed down Alpine derivative that supports (separately) both musl and glibc versions.  It's primarily targeted as a container delivery vehicle for BellSoft's [Liberica JDK](https://bell-sw.com/libericajdk/)

- https://bell-sw.com/alpaquita-linux/
- https://github.com/bell-sw/alpaquita-aports

I hope I have correctly inferred what this module has to do.  One thing I'm not entirely sure about is the place to normalize the variant from the implicit "default" into explicit "musl", so that variant can be omitted in image, but listed as "musl" (vs. "glibc") in filters further down the yaml config.  Feedback/guidance is appreciated.

As far as I understand, the architecture mappings are not required if the architecture naming is the same as the one distrobuilder itself uses?

Thanks
