### PR TITLE
Replace libguestfs-tools with libwin-hivex-perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To compile `distrobuilder` from source, first install the Go programming languag
 - Debian-based:
     ```
     sudo apt update
-    sudo apt install -y golang-go gcc debootstrap rsync gpg squashfs-tools git make build-essential libguestfs-tools wimtools genisoimage
+    sudo apt install -y golang-go gcc debootstrap rsync gpg squashfs-tools git make build-essential libwin-hivex-perl wimtools genisoimage
     ```
 
 - ArchLinux-based:


### PR DESCRIPTION
Current dependencies contain `libguestfs-tools` which is quite a big package with many tools.
If Distrobuilder only needs `hivexregedit` command its provided for Debian/Ubuntu by separate package `libwin-hivex-perl`.

`libwin-hivex-perl` is also linked as provider in manpages for `hivexregedit` command: https://manpages.ubuntu.com/manpages/noble/man1/hivexregedit.1.html