### PR TITLE
doc: Document runtime deps for building VM images

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ $HOME/go/bin/distrobuilder
 ```
 
 You may also add the directory `$HOME/go/bin/` to your $PATH so that you do not need to run the command with the full path.
+
+## Runtime dependencies for building VM images
+
+If you intend to build Incus VM images (via `distrobuilder build-incus --vm`),
+your system will need certain tools installed:
+
+- Debian-based:
+    ```
+    sudo apt update
+    sudo apt install -y btrfs-progs dosfstools qemu-kvm
+    ```
+
 <!-- Include end installing -->
 
 ## How to use

--- a/doc/howto/build.md
+++ b/doc/howto/build.md
@@ -146,6 +146,8 @@ See the [image section](../reference/image.md) for more on the image name.
 If `--compression` is set, the tarballs will use the provided compression instead of `xz`.
 
 Setting `--vm` will create a `qcow2` image which is used for virtual machines.
+This requires some extra tools to be installed on your host - see [How to
+install `distrobuilder`](install.md) for instructions.
 
 If `--import-into-incus` is set, the resulting image is imported into Incus.
 It basically runs `lxc image import <image>`.


### PR DESCRIPTION
I don't know what these packages would be called on other systems but I'm at least just writing down what I do know :)

Note it might be that `qemu-kvm` is overkill and there's some lesser package that would do the job here.