### PR TITLE
Usage: Set image.os for Windows installation

### DIFF
--- a/doc/tutorials/use.md
+++ b/doc/tutorials/use.md
@@ -175,7 +175,7 @@ distrobuilder repack-windows -h
 Run the following commands to initialize the VM, to configure (=increase) the allocated disk space and finally attach the full path of your prepared ISO file. Note that the installation of Windows 10 takes about 10GB (before updates), therefore a 30GB disk gives you about 20GB of free space.
 
 ```bash
-incus init win10 --empty --vm -c security.secureboot=false
+incus init win10 --empty --vm -c security.secureboot=false -c image.os="Windows 10"
 incus config device override win10 root size=30GiB
 incus config device add win10 iso disk source=/path/to/Windows-repacked.iso boot.priority=10
 ```


### PR DESCRIPTION
> When creating a Windows virtual machine, make sure to set the image.os property to something starting with Windows. Doing so will tell Incus to expect Windows to be running inside of the virtual machine and to tweak behavior accordingly.
>
> This notably will cause:
> - Some unsupported virtual devices to be disabled
> - The RTC clock to be based on system local time rather than UTC
> - IOMMU handling to switch to an Intel IOMMU controller


See <https://linuxcontainers.org/incus/docs/main/howto/instances_create/#launch-a-vm-that-boots-from-an-iso>

Also we could update the doc for Windows 11 installation.
We can avoid the `security.secureboot=false` and meet [minimal requirements](https://aka.ms/WindowsSysReq):
- 2 CPU
- 4GiB RAM
- 64GiB disk
- TPM device

Tested yesterday and it seems to work