### PR TITLE
utils_test.go: TestRecvGPGKeys add missing cleanup

### DIFF
--- a/sources/utils_test.go
+++ b/sources/utils_test.go
@@ -259,6 +259,9 @@ invalid public key`,
 				t.Fatal(err)
 			}
 
+			defer func() {
+				os.RemoveAll(gpgDir)
+			}()
 			want, err := recvGPGKeys(context.Background(), gpgDir, "", tc.keys)
 			if want != tc.want {
 				t.Fatal(want, tc.want, err)


### PR DESCRIPTION
Need to remove `gpgDir` after the test so that no gpg-agent processes are left behind loitering.