### PR TITLE
Update almalinux-http.go

### DIFF
--- a/sources/almalinux-http.go
+++ b/sources/almalinux-http.go
@@ -69,7 +69,7 @@ func (s *almalinux) Run() error {
 			if s.definition.Image.ArchitectureMapped == "armhfp" {
 				checksumFile = "sha256sum.txt"
 			} else {
-				if strings.HasPrefix(s.definition.Image.Release, "8") {
+				if strings.HasPrefix(s.definition.Image.Release, "8") || strings.HasPrefix(s.definition.Image.Release, "9") || strings.HasPrefix(s.definition.Image.Release, "10") {
 					checksumFile = "CHECKSUM"
 				} else {
 					checksumFile = "sha256sum.txt.asc"
@@ -120,8 +120,8 @@ func (s *almalinux) rawRunner() error {
 
 	# Create a minimal rootfs
 	mkdir /rootfs
-	yum --installroot=/rootfs --disablerepo=* --enablerepo=base -y --releasever=%s install basesystem almalinux-release yum
-	rm -rf /rootfs/var/cache/yum
+	dnf --installroot=/rootfs --disablerepo=* --enablerepo=baseos -y --releasever=%s install basesystem almalinux-release dnf rpm shadow-utils
+	rm -rf /rootfs/var/cache/dnf
 	`, s.majorVersion))
 	if err != nil {
 		return fmt.Errorf("Failed to run script: %w", err)
@@ -139,14 +139,14 @@ GPG_KEYS="%s"
 # Create required files
 touch /etc/mtab /etc/fstab
 
-yum_args=""
+dnf_args=""
 mkdir -p /etc/yum.repos.d
 
 if [ -d /mnt/cdrom ]; then
 	# Install initial package set
 	cd /mnt/cdrom/Packages
 	rpm -ivh --nodeps $(ls rpm-*.rpm | head -n1)
-	rpm -ivh --nodeps $(ls yum-*.rpm | head -n1)
+	rpm -ivh --nodeps $(ls dnf-*.rpm | head -n1)
 
 	# Add cdrom repo
 	cat <<- EOF > /etc/yum.repos.d/cdrom.repo
@@ -163,8 +163,8 @@ if [ -d /mnt/cdrom ]; then
 		echo gpgcheck=0 >> /etc/yum.repos.d/cdrom.repo
 	fi
 
-	yum_args="--disablerepo=* --enablerepo=cdrom"
-	yum ${yum_args} -y reinstall yum
+	dnf_args="--disablerepo=* --enablerepo=cdrom"
+	dnf ${dnf_args} -y reinstall dnf
 else
 	if ! [ -f /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux ]; then
 		mv /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-* /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
@@ -173,22 +173,19 @@ else
 	cat <<- "EOF" > /etc/yum.repos.d/almalinux.repo
 	[baseos]
 	name=AlmaLinux $releasever - BaseOS
-	baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
+	mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
 	gpgcheck=1
 	enabled=1
 	gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
 	EOF
-
-	# Use dnf in the boot iso since yum isn't available
-	alias yum=dnf
 fi
 
-pkgs="basesystem almalinux-release yum"
+pkgs="basesystem almalinux-release dnf rpm shadow-utils grubby"
 
 # Create a minimal rootfs
 mkdir /rootfs
-yum ${yum_args} --installroot=/rootfs -y --releasever=%s --skip-broken install ${pkgs}
-rm -rf /rootfs/var/cache/yum
+dnf ${dnf_args} --installroot=/rootfs -y --releasever=%s --nogpgcheck --skip-broken install ${pkgs}
+rm -rf /rootfs/var/cache/dnf
 `, gpgKeysPath, s.majorVersion))
 	if err != nil {
 		return fmt.Errorf("Failed to run script: %w", err)


### PR DESCRIPTION
I recently needed AlmaLinux 10 CT and VM instance images for Incus. As they weren't available yet I modified Distrobuilder a little to be able to roll these images up for us.

For more details see:

https://github.com/lxc/lxc-ci/issues/892#issuecomment-2942987581

- [CT image almalinux/10/cloud](http://updates3.blueonyx.it/.incus/alma10-cloud-ct/) ([build logfile](http://updates3.blueonyx.it/.incus/alma10-cloud.log.txt))
- [VM image almalinux/10/cloud](http://updates3.blueonyx.it/.incus/alma10-cloud-vm/) ([build logfile](http://updates3.blueonyx.it/.incus/alma10-cloud-vm.log.txt))
- [Modified almalinux.yaml](http://updates3.blueonyx.it/.incus/almalinux.yaml.txt) (Alma 8/9/10)
- [Modified almalinux-http.go](http://updates3.blueonyx.it/.incus/almalinux-http.go.txt) for Distrobuilder
