### PR TITLE
systemd-generator: some more exceptions

### DIFF
--- a/distrobuilder/lxc.generator
+++ b/distrobuilder/lxc.generator
@@ -91,9 +91,11 @@ fix_systemd_override_unit() {
 		echo "[Service]";
 		[ "${SYSTEMD}" -ge 247 ] && echo "ProcSubset=all";
 		[ "${SYSTEMD}" -ge 247 ] && echo "ProtectProc=default";
+		[ "${SYSTEMD}" -ge 232 ] && echo "PrivateUsers=no";
 		[ "${SYSTEMD}" -ge 232 ] && echo "ProtectControlGroups=no";
 		[ "${SYSTEMD}" -ge 232 ] && echo "ProtectKernelTunables=no";
 		[ "${SYSTEMD}" -ge 239 ] && echo "NoNewPrivileges=no";
+		[ "${SYSTEMD}" -ge 239 ] && echo "PrivateMounts=no";
 		[ "${SYSTEMD}" -ge 249 ] && echo "LoadCredential=";
 		[ "${SYSTEMD}" -ge 254 ] && echo "PrivateNetwork=no";
 		[ "${SYSTEMD}" -ge 256 ] && echo "ImportCredential=";


### PR DESCRIPTION
Hello,

this pull-request is a work in progress. Feel free to comment, and overtake it or discard it after a week without activity.

It adds some more systemd exceptions in the `lxc.generator` script for the program nullmailer in Debian 13 Trixie.

I think I tested with a pretty standard configuration, both in privileged and unprivileged containers , except for `lxc.apparmor.profile` where the `generated` setting fails with unprivileged containers (even with `/usr/sbin/apparmor_parser` in the `$PATH`):
```
#lxc.apparmor.profile = generated
lxc.apparmor.profile = lxc-container-default-cgns
```

I am still studying the reason of the `if is_lxc_privileged_container...` at line 102-104 because unprivileged containers also need those configurations and I tend to replace it with a `if true; then` (hoping it doesn't decrease security too much...)

And, for reference, here is the (heavily sandboxed) nullmailer's systemd service file on Debian 13:
```ini
[Unit]
Description=Nullmailer relay-only MTA
After=network.target
RequiresMountsFor=/var/spool/nullmailer
ConditionPathExists=/var/spool/nullmailer/queue
Documentation=man:nullmailer(7)

[Service]
WorkingDirectory=/var/spool/nullmailer
ExecStart=/usr/sbin/nullmailer-send
User=mail
Group=mail
Restart=always
SyslogFacility=mail

# Sandboxing
CapabilityBoundingSet=
MemoryDenyWriteExecute=yes
NoNewPrivileges=yes
PrivateDevices=yes
PrivateMounts=yes
PrivateTmp=yes
PrivateUsers=yes
ProtectClock=yes
ProtectControlGroups=yes
ProtectHome=yes
ProtectHostname=yes
ProtectKernelLogs=yes
ProtectKernelModules=yes
ProtectKernelTunables=yes
ProtectProc=invisible
ProtectSystem=strict
ReadWriteDirectories=-/var/log
ReadWriteDirectories=-/var/run
ReadWriteDirectories=-/var/spool/nullmailer
RestrictNamespaces=yes
RestrictRealtime=yes
RestrictSUIDSGID=yes

[Install]
WantedBy=multi-user.target
```