### PR TITLE
sources/almalinux-http: Use CHECKSUM for AlmaLinux 8, 9 and 10

### DIFF
--- a/sources/almalinux-http.go
+++ b/sources/almalinux-http.go
@@ -69,11 +69,10 @@ func (s *almalinux) Run() error {
 			if s.definition.Image.ArchitectureMapped == "armhfp" {
 				checksumFile = "sha256sum.txt"
 			} else {
-				if strings.HasPrefix(s.definition.Image.Release, "8") ||
-					strings.HasPrefix(s.definition.Image.Release, "9") ||
-					strings.HasPrefix(s.definition.Image.Release, "10") {
+				switch s.majorVersion {
+				case "8", "9", "10":
 					checksumFile = "CHECKSUM"
-				} else {
+				default:
 					checksumFile = "sha256sum.txt.asc"
 				}
 			}


### PR DESCRIPTION
## Description

AlmaLinux 8, 9 and 10 use a `CHECKSUM` file for verification. This PR updates the logic to check for `CHECKSUM` when the release is 8, 9 or 10, fixing the download failure for versions 9 and 10.

The version check logic has been refactored from chained `strings.HasPrefix()` calls to a cleaner `switch` statement using the existing `majorVersion` variable, improving code readability and maintainability.

Additionally, this change ensures that `CHECKSUM` files are correctly passed to `VerifyFile`, addressing a security oversight where AlmaLinux 8 downloads were determining the correct file but skipping GPG verification.

## Verification

**AlmaLinux 10 Download Fix Verification:**

- Test with only AlmaLinux 10

**Failure before changes:**

```bash
INFO   [2026-01-06T14:52:43+08:00] Downloading source
Error: Error while downloading source: Failed to download "http://mirrors.xtom.com/almalinux/10/isos/x86_64/sha256sum.txt.asc": Unable to fetch http://mirrors.xtom.com/almalinux/10/isos/x86_64/sha256sum.txt.asc: resource not found
ERROR  [2026-01-06T14:52:48+08:00] Failed running distrobuilder                  err="Error while downloading source: Failed to download \"http://mirrors.xtom.com/almalinux/10/isos/x86_64/sha256sum.txt.asc\": Unable to fetch http://mirrors.xtom.com/almalinux/10/isos/x86_64/sha256sum.txt.asc: resource not found"
INFO   [2026-01-06T14:52:48+08:00] Removing cache directory
```

**Success after changes:**

```bash
INFO   [2026-01-06T14:56:14+08:00] Downloading source
/tmp/distrobuilder/almalinux-10-x86_64/CHECKSUM: 100% (1.87kB/s)
gpg: Signature made Thu Nov 20 03:37:44 2025 CST
gpg:                using RSA key EE6DB7B98F5BF5EDD9DA0DE5DEE5C11CC2A1E572
gpg: Good signature from "AlmaLinux OS 10 <packager@almalinux.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: EE6D B7B9 8F5B F5ED D9DA  0DE5 DEE5 C11C C2A1 E572
/tmp/distrobuilder/almalinux-10-x86_64/AlmaLinux-10.1-x86_64-boot.iso: 100% (47.69MB/s)
INFO   [2026-01-06T14:56:36+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/almalinux-10-x86_64/AlmaLinux-10.1-x86_64-boot.iso
INFO   [2026-01-06T14:56:36+08:00] Unpacking root image                          file=/var/cache/distrobuilder.299397506/temp_608682421/images/install.img
```

**AlmaLinux 8 Security Fix Verification:**

**Before the changes (GPG check bypassed):**

```bash
INFO   [2026-01-06T15:20:51+08:00] Downloading source
/tmp/distrobuilder/almalinux-8-x86_64/CHECKSUM: 100% (1.86kB/s)
// <- Skip the gpg verification here
/tmp/distrobuilder/almalinux-8-x86_64/AlmaLinux-8.10-x86_64-boot.iso: 100% (53.09MB/s)
INFO   [2026-01-06T15:21:12+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/almalinux-8-x86_64/AlmaLinux-8.10-x86_64-boot.iso
INFO   [2026-01-06T15:21:12+08:00] Unpacking root image                          file=/var/cache/distrobuilder.386023714/temp_3590222652/images/install.img
```

**After the changes (GPG check enforced):**

```bash
INFO   [2026-01-06T15:22:36+08:00] Downloading source
/tmp/distrobuilder/almalinux-8-x86_64/CHECKSUM: 100% (1.86kB/s)
gpg: Signature made Sat May 25 16:03:41 2024 CST
gpg:                using RSA key BC5EDDCADF502C077F1582882AE81E8ACED7258B
gpg: Good signature from "AlmaLinux OS 8 <packager@almalinux.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: BC5E DDCA DF50 2C07 7F15  8288 2AE8 1E8A CED7 258B
INFO   [2026-01-06T15:22:38+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/almalinux-8-x86_64/AlmaLinux-8.10-x86_64-boot.iso
INFO   [2026-01-06T15:22:38+08:00] Unpacking root image                          file=/var/cache/distrobuilder.3099264887/temp_3031873158/images/install.img
```
