### PR TITLE
Enforce GPG verification across multiple distros (Fixes #963)

### DIFF
--- a/sources/archlinux-http.go
+++ b/sources/archlinux-http.go
@@ -59,18 +59,19 @@ func (s *archlinux) Run() error {
 		return fmt.Errorf("Failed to parse URL %q: %w", tarball, err)
 	}
 
-	if !s.definition.Source.SkipVerification && url.Scheme != "https" &&
-		len(s.definition.Source.Keys) == 0 {
-		return errors.New("GPG keys are required if downloading from HTTP")
+	skip, err := s.validateGPGRequirements(url)
+	if err != nil {
+		return fmt.Errorf("Failed to validate GPG requirements: %w", err)
 	}
+
+	s.definition.Source.SkipVerification = skip
 
 	fpath, err := s.DownloadHash(s.definition.Image, tarball, "", nil)
 	if err != nil {
 		return fmt.Errorf("Failed to download %q: %w", tarball, err)
 	}
 
-	// Force gpg checks when using http
-	if !s.definition.Source.SkipVerification && url.Scheme != "https" {
+	if !s.definition.Source.SkipVerification {
 		_, err = s.DownloadHash(s.definition.Image, tarball+".sig", "", nil)
 		if err != nil {
 			return fmt.Errorf("Failed downloading %q: %w", tarball+".sig", err)

--- a/sources/funtoo-http.go
+++ b/sources/funtoo-http.go
@@ -1,7 +1,6 @@
 package sources
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -47,10 +46,12 @@ func (s *funtoo) Run() error {
 		return fmt.Errorf("Failed to parse URL %q: %w", tarball, err)
 	}
 
-	if !s.definition.Source.SkipVerification && url.Scheme != "https" &&
-		len(s.definition.Source.Keys) == 0 {
-		return errors.New("GPG keys are required if downloading from HTTP")
+	skip, err := s.validateGPGRequirements(url)
+	if err != nil {
+		return fmt.Errorf("Failed to validate GPG requirements: %w", err)
 	}
+
+	s.definition.Source.SkipVerification = skip
 
 	var fpath string
 
@@ -59,8 +60,7 @@ func (s *funtoo) Run() error {
 		return fmt.Errorf("Failed to download %q: %w", tarball, err)
 	}
 
-	// Force gpg checks when using http
-	if !s.definition.Source.SkipVerification && url.Scheme != "https" {
+	if !s.definition.Source.SkipVerification {
 		_, err = s.DownloadHash(s.definition.Image, tarball+".gpg", "", nil)
 		if err != nil {
 			return fmt.Errorf("Failed to download %q: %w", tarball+".gpg", err)


### PR DESCRIPTION
## Description

This PR standardizes and enforces GPG verification requirements across multiple supported distributions. The primary change is the introduction of a `validateGPGRequirements` helper in `common.go`, which implements the following logic requested in #963:

- **HTTP**: A GPG keyring is now strictly **required**. If a GPG keyring is not specified/available, the build will fail early.
- **HTTPS**: If a GPG keyring is specified, it is used. If not, the download proceeds with a warning, leveraging the transport layer security of HTTPS but alerting the user to the lack of correct signature verification.
- **Explicit Keys**: If `keys` are defined in the source definition, verification is always enforced, regardless of the protocol.

This logic has been applied to `almalinux`, `alpine`, `archlinux`, `centos`, `funtoo`, `gentoo`, `rocky`, `ubuntu`, and `voidlinux` sources.

Specific security fixes included:

- **Rocky Linux**: Fixed an issue where the `CHECKSUM` file was downloaded but not verified against its signature.
- **CentOS**: Fixed an issue where 'SHA256SUM' and 'CHECKSUM' files were downloaded but not GPG verified.
- **Gentoo**: The portage snapshot download now correctly re-parses the URL and calls `validateGPGRequirements`, ensuring GPG checks are enforced unless explicitly skipped.

Unit tests for `validateGPGRequirements` have been added in `common_test.go`.

Fixes #963

## Verification

- **Scenario 1: Any protocol with keys** — GPG verification is always performed, regardless of `skip_verification` setting.
- **Scenario 2: HTTP without keys** — Build fails with an error requiring GPG keys.
- **Scenario 3: HTTPS without keys and `skip_verification` equals false** — Build proceeds with a warning about missing GPG verification.
