### PR TITLE
Fix CentOS Stream 10 checksum file retrieval (follow-up #966)

### DIFF
--- a/sources/centos-http.go
+++ b/sources/centos-http.go
@@ -89,7 +89,7 @@ func (s *centOS) Run() error {
 			checksumFile = "sha256sum.txt"
 		} else {
 			checksumFile = "sha256sum.txt.asc"
-			if strings.HasPrefix(s.definition.Image.Release, "9") {
+			if strings.HasPrefix(s.definition.Image.Release, "9") || strings.HasPrefix(s.definition.Image.Release, "10") {
 				checksumFile = "SHA256SUM"
 			} else if strings.HasPrefix(s.definition.Image.Release, "8") {
 				checksumFile = "CHECKSUM"


### PR DESCRIPTION
## Problem

While verifying the fixes from my previous PR #966, a specific issue with CentOS Stream 10 was identified.

CentOS Stream 10 builds fail as attempting to fetch `sha256sum.txt.asc`. Like CentOS Stream 9, Stream 10 uses a single `SHA256SUM` file.

**Error Log:**

```bash
INFO [2026-01-10T21:31:14+08:00] Downloading source
Error: Error while downloading source: Failed to download "http://mirrors.xtom.com/centos-stream//10-stream/BaseOS/x86_64/iso/sha256sum.txt.asc": Unable to fetch http://mirrors.xtom.com/centos-stream//10-stream/BaseOS/x86_64/iso/sha256sum.txt.asc: resource not found
ERROR [2026-01-10T21:31:17+08:00] Failed running distrobuilder err="Error while downloading source: Failed to download \"http://mirrors.xtom.com/centos-stream//10-stream/BaseOS/x86_64/iso/sha256sum.txt.asc\": Unable to fetch http://mirrors.xtom.com/centos-stream//10-stream/BaseOS/x86_64/iso/sha256sum.txt.asc: resource not found"
```

## Fix

Updated `sources/centos-http.go` to apply the same checksum file logic used for CentOS Stream 9 to CentOS Stream 10.

## Verification

Verified success for CentOS Stream 10. Also verified stability across other recently fixed distributions (VoidLinux, Gentoo, Rocky Linux) to ensure no issues.

### Verification Logs

<details>
<summary>VoidLinux (Only HTTPS) (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/voidlinux.yaml ./rootfs-test \
 -o image.architecture=x86_64 \
 -o image.release=current \
 -o source.url=https://mirrors.cicku.me/voidlinux/live/current/
INFO [2026-01-10T21:43:57+08:00] Downloading source
INFO [2026-01-10T21:43:58+08:00] Unpacking image file=/tmp/distrobuilder/voidlinux-current-x86_64/void-x86_64-ROOTFS-20250202.tar.xz
```

</details>

<details>
<summary>Gentoo OpenRC (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/gentoo.yaml ./rootfs-test \
 -o image.architecture=amd64 \
 -o source.variant=openrc \
 -o image.variant=openrc \
 -o source.url=http://mirrors.kernel.org/gentoo/
INFO [2026-01-10T21:47:46+08:00] Downloading source
/tmp/distrobuilder/gentoo--amd64/stage3-amd64-openrc-20260107T201601Z.tar.xz: 100% (7.35MB/s))
gpg: Signature made Thu Jan 8 05:01:06 2026 CST
gpg: using RSA key 534E4209AB49EEE1C19D96162C44695DB9F6043D
gpg: Good signature from "Gentoo Linux Release Engineering (Automated Weekly Release Key) <releng@gentoo.org>" [expired]
gpg: Signature notation: manu=2,2.5+1.11,2,2
gpg: Note: This key has expired!
Primary key fingerprint: 13EB BDBE DE7A 1277 5DFD B1BA BB57 2E0E 2D18 2910
Subkey fingerprint: 534E 4209 AB49 EEE1 C19D 9616 2C44 695D B9F6 043D
INFO [2026-01-10T21:48:48+08:00] Unpacking image file=/tmp/distrobuilder/gentoo--amd64/stage3-amd64-openrc-20260107T201601Z.tar.xz
```

</details>

<details>
<summary>Gentoo Systemd (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/gentoo.yaml ./rootfs-test \
 -o image.architecture=amd64 \
 -o source.variant=systemd \
 -o image.variant=systemd \
 -o source.url=http://mirrors.kernel.org/gentoo/
INFO [2026-01-10T21:54:54+08:00] Downloading source
/tmp/distrobuilder/gentoo--amd64/stage3-amd64-systemd-20260107T201601Z.tar.xz: 100% (8.41MB/s))
gpg: Signature made Thu Jan 8 09:21:07 2026 CST
gpg: using RSA key 534E4209AB49EEE1C19D96162C44695DB9F6043D
gpg: Good signature from "Gentoo Linux Release Engineering (Automated Weekly Release Key) <releng@gentoo.org>" [expired]
gpg: Signature notation: manu=2,2.5+1.11,2,2
gpg: Note: This key has expired!
Primary key fingerprint: 13EB BDBE DE7A 1277 5DFD B1BA BB57 2E0E 2D18 2910
Subkey fingerprint: 534E 4209 AB49 EEE1 C19D 9616 2C44 695D B9F6 043D
INFO [2026-01-10T21:55:51+08:00] Unpacking image file=/tmp/distrobuilder/gentoo--amd64/stage3-amd64-systemd-20260107T201601Z.tar.xz
```

</details>

<details>
<summary>CentOS Stream 10 (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/centos.yaml ./rootfs-test \
 -o image.architecture=x86_64 \
 -o image.variant=default \
 -o source.variant=boot \
 -o source.url=http://mirrors.xtom.com/centos-stream/
INFO [2026-01-10T21:46:06+08:00] Downloading source
/tmp/distrobuilder/centos-10-stream-x86_64/SHA256SUM: 100% (368B/s)
INFO [2026-01-10T21:46:08+08:00] Unpacking image file=/tmp/distrobuilder/centos-10-stream-x86_64/CentOS-Stream-10-20260105.0-x86_64-boot.iso
```

</details>

<details>
<summary>CentOS Stream 9 (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/centos.yaml ./rootfs-test \
 -o image.architecture=x86_64 \
 -o image.release=9-Stream \
 -o image.variant=default \
 -o source.variant=boot \
 -o source.url=http://mirrors.xtom.com/centos-stream/
INFO [2026-01-10T21:46:38+08:00] Downloading source
/tmp/distrobuilder/centos-9-stream-x86_64/SHA256SUM: 100% (365B/s)
INFO [2026-01-10T21:46:41+08:00] Unpacking image file=/tmp/distrobuilder/centos-9-stream-x86_64/CentOS-Stream-9-20260105.0-x86_64-boot.iso
```

</details>

<details>
<summary>Rocky Linux 10 (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/rockylinux.yaml ./rootfs \
 -o image.architecture=x86_64 \
 -o image.release=10 \
 -o image.variant=default \
 -o source.variant=boot \
 -o source.url=http://mirrors.xtom.com/rocky/
INFO   [2026-01-10T22:15:20+08:00] Downloading source
/tmp/distrobuilder/rockylinux-10-x86_64/CHECKSUM: 100% (938B/s)
gpg: Signature made Sat Nov 22 02:50:42 2025 CST
gpg:                using RSA key FC226859C0860BF0DDB95B085B106C736FEDFC85
gpg: Good signature from "Release Engineering (Rocky Linux 10) <releng@rockylinux.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: FC22 6859 C086 0BF0 DDB9  5B08 5B10 6C73 6FED FC85
INFO   [2026-01-10T22:15:21+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/rockylinux-10-x86_64/Rocky-10.1-x86_64-boot.iso
INFO   [2026-01-10T22:15:21+08:00] Unpacking root image                          file=/var/cache/distrobuilder.120117154/temp_76430491/images/install.img
```

</details>

<details>
<summary>Rocky Linux 9 (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/rockylinux.yaml ./rootfs \
 -o image.architecture=x86_64 \
 -o image.release=9 \
 -o image.variant=default \
 -o source.variant=boot \
 -o source.url=https://mirrors.xtom.com/rocky/
INFO   [2026-01-10T22:15:44+08:00] Downloading source
/tmp/distrobuilder/rockylinux-9-x86_64/CHECKSUM: 100% (928B/s)
INFO   [2026-01-10T22:15:46+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/rockylinux-9-x86_64/Rocky-9.7-x86_64-boot.iso
```

</details>

<details>
<summary>Rocky Linux 8 (Verification - Passed)</summary>

```bash
sudo distrobuilder build-dir lxc-ci/images/rockylinux.yaml ./rootfs \
 -o image.architecture=x86_64 \
 -o image.release=9 \
 -o image.variant=default \
 -o source.variant=boot \
 -o source.url=https://mirrors.xtom.com/rocky/
INFO   [2026-01-10T22:16:38+08:00] Downloading source
/tmp/distrobuilder/rockylinux-8-x86_64/CHECKSUM: 100% (1.50kB/s)
INFO   [2026-01-10T22:16:39+08:00] Unpacking ISO                                 file=/tmp/distrobuilder/rockylinux-8-x86_64/Rocky-8.10-x86_64-boot.iso
```

</details>
