### PR TITLE
Fix portage snapshot GPG verification

### DIFF
--- a/sources/gentoo.go
+++ b/sources/gentoo.go
@@ -131,8 +131,8 @@ func (s *gentoo) Run() error {
 		}
 
 		valid, err := s.VerifyFile(
-			filepath.Join(fpath, fname+".gpgsig"),
-			"")
+			filepath.Join(fpath, fname),
+			filepath.Join(fpath, fname+".gpgsig"))
 		if err != nil {
 			return fmt.Errorf("Failed to verify %q: %w", filepath.Join(fpath, fname+".gpgsig"), err)
 		}


### PR DESCRIPTION
## Description

This PR fixes the portage snapshot GPG verification logic in `sources/gentoo.go`.

It ensures that the detached signature file (`portage-latest.tar.xz.gpgsig`) is correctly verified against the snapshot using the available GPG keys.

## Changes

- `sources/gentoo.go`: Fix GPG verification logic for the portage snapshot.
