### PR TITLE
global: Update for semver tags

### DIFF
--- a/distrobuilder/main.go
+++ b/distrobuilder/main.go
@@ -71,10 +71,10 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/distrobuilder/managers"
-	"github.com/lxc/distrobuilder/shared"
-	"github.com/lxc/distrobuilder/shared/version"
-	"github.com/lxc/distrobuilder/sources"
+	"github.com/lxc/distrobuilder/v3/managers"
+	"github.com/lxc/distrobuilder/v3/shared"
+	"github.com/lxc/distrobuilder/v3/shared/version"
+	"github.com/lxc/distrobuilder/v3/sources"
 )
 
 //go:embed lxc.generator

--- a/distrobuilder/main_build-dir.go
+++ b/distrobuilder/main_build-dir.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/distrobuilder/generators"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/generators"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type cmdBuildDir struct {

--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -16,10 +16,10 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/generators"
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/managers"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/generators"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/managers"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type cmdIncus struct {

--- a/distrobuilder/main_lxc.go
+++ b/distrobuilder/main_lxc.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/distrobuilder/generators"
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/managers"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/generators"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/managers"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type cmdLXC struct {

--- a/distrobuilder/main_repack-windows.go
+++ b/distrobuilder/main_repack-windows.go
@@ -18,8 +18,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/shared"
-	"github.com/lxc/distrobuilder/windows"
+	"github.com/lxc/distrobuilder/v3/shared"
+	"github.com/lxc/distrobuilder/v3/windows"
 )
 
 type cmdRepackWindows struct {

--- a/distrobuilder/vm.go
+++ b/distrobuilder/vm.go
@@ -13,7 +13,7 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type vm struct {

--- a/distrobuilder/vm_test.go
+++ b/distrobuilder/vm_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func lsblkOutputHelper(t *testing.T, v *vm, args [][]string) func() {

--- a/generators/cloud-init.go
+++ b/generators/cloud-init.go
@@ -10,8 +10,8 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type cloudInit struct {

--- a/generators/cloud-init_test.go
+++ b/generators/cloud-init_test.go
@@ -11,8 +11,8 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestCloudInitGeneratorRunLXC(t *testing.T) {

--- a/generators/common.go
+++ b/generators/common.go
@@ -3,7 +3,7 @@ package generators
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type common struct {

--- a/generators/copy.go
+++ b/generators/copy.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type copy struct {

--- a/generators/copy_test.go
+++ b/generators/copy_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestCopyGeneratorRun(t *testing.T) {

--- a/generators/dump.go
+++ b/generators/dump.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type dump struct {

--- a/generators/dump_test.go
+++ b/generators/dump_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestDumpGeneratorRunLXC(t *testing.T) {

--- a/generators/fstab.go
+++ b/generators/fstab.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type fstab struct {

--- a/generators/generators.go
+++ b/generators/generators.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 // ErrNotSupported returns a "Not supported" error.

--- a/generators/generators_test.go
+++ b/generators/generators_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func setup(t *testing.T, cacheDir string) {

--- a/generators/hostname.go
+++ b/generators/hostname.go
@@ -8,8 +8,8 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type hostname struct {

--- a/generators/hostname_test.go
+++ b/generators/hostname_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestHostnameGeneratorRunLXC(t *testing.T) {

--- a/generators/hosts.go
+++ b/generators/hosts.go
@@ -9,8 +9,8 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type hosts struct {

--- a/generators/hosts_test.go
+++ b/generators/hosts_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestHostsGeneratorRunLXC(t *testing.T) {

--- a/generators/incus-agent.go
+++ b/generators/incus-agent.go
@@ -10,8 +10,8 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 var incusAgentSetupScript = `#!/bin/sh

--- a/generators/remove.go
+++ b/generators/remove.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type remove struct {

--- a/generators/template.go
+++ b/generators/template.go
@@ -9,8 +9,8 @@ import (
 	"github.com/flosch/pongo2/v4"
 	"github.com/lxc/incus/v6/shared/api"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type template struct {

--- a/generators/template_test.go
+++ b/generators/template_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/image"
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/image"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestTemplateGeneratorRunIncus(t *testing.T) {

--- a/generators/utils.go
+++ b/generators/utils.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func updateFileAccess(file *os.File, defFile shared.DefinitionFile) error {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lxc/distrobuilder
+module github.com/lxc/distrobuilder/v3
 
 go 1.25.6
 
@@ -56,7 +56,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-containerregistry v0.21.0 // indirect
+	github.com/google/go-containerregistry v0.21.1 // indirect
 	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -118,7 +118,7 @@ require (
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260217215200-42d3e9bedb6d // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260223185530-2f722ef697dc // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc // indirect
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-containerregistry v0.21.0 h1:ocqxUOczFwAZQBMNE7kuzfqvDe0VWoZxQMOesXreCDI=
-github.com/google/go-containerregistry v0.21.0/go.mod h1:ctO5aCaewH4AK1AumSF5DPW+0+R+d2FmylMJdp5G7p0=
+github.com/google/go-containerregistry v0.21.1 h1:sOt/o9BS2b87FnR7wxXPvRKU1XVJn2QCwOS5g8zQXlc=
+github.com/google/go-containerregistry v0.21.1/go.mod h1:ctO5aCaewH4AK1AumSF5DPW+0+R+d2FmylMJdp5G7p0=
 github.com/google/go-github/v56 v56.0.0 h1:TysL7dMa/r7wsQi44BjqlwaHvwlFlqkK8CtBWCX3gb4=
 github.com/google/go-github/v56 v56.0.0/go.mod h1:D8cdcX98YWJvi7TLo7zM4/h8ZTx6u6fwGEkCdisopo0=
 github.com/google/go-intervals v0.0.2 h1:FGrVEiUnTRKR8yE04qzXYaJMtnIYqobR5QbblK3ixcM=
@@ -437,8 +437,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
-google.golang.org/genproto/googleapis/api v0.0.0-20260217215200-42d3e9bedb6d h1:EocjzKLywydp5uZ5tJ79iP6Q0UjDnyiHkGRWxuPBP8s=
-google.golang.org/genproto/googleapis/api v0.0.0-20260217215200-42d3e9bedb6d/go.mod h1:48U2I+QQUYhsFrg2SY6r+nJzeOtjey7j//WBESw+qyQ=
+google.golang.org/genproto/googleapis/api v0.0.0-20260223185530-2f722ef697dc h1:ULD+ToGXUIU6Pkzr1ARxdyvwfHbelw+agoFDRbLg4TU=
+google.golang.org/genproto/googleapis/api v0.0.0-20260223185530-2f722ef697dc/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc h1:51Wupg8spF+5FC6D+iMKbOddFjMckETnNnEiZ+HX37s=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.79.1 h1:zGhSi45ODB9/p3VAawt9a+O/MULLl9dpizzNNpq7flY=

--- a/image/incus.go
+++ b/image/incus.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	"gopkg.in/yaml.v2"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 // An IncusImage represents an Incus image.

--- a/image/incus_test.go
+++ b/image/incus_test.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 var incusDef = shared.Definition{

--- a/image/lxc.go
+++ b/image/lxc.go
@@ -10,7 +10,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 const maxLXCCompatLevel = 5

--- a/image/lxc_test.go
+++ b/image/lxc_test.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 var lxcDef = shared.Definition{

--- a/managers/anise.go
+++ b/managers/anise.go
@@ -9,7 +9,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type anise struct {

--- a/managers/apk.go
+++ b/managers/apk.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type apk struct {

--- a/managers/apt.go
+++ b/managers/apt.go
@@ -10,7 +10,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type apt struct {

--- a/managers/common.go
+++ b/managers/common.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type common struct {

--- a/managers/dnf.go
+++ b/managers/dnf.go
@@ -1,7 +1,7 @@
 package managers
 
 import (
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type dnf struct {

--- a/managers/equo.go
+++ b/managers/equo.go
@@ -3,7 +3,7 @@ package managers
 import (
 	"errors"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type equo struct {

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 // ErrUnknownManager represents the unknown manager error.

--- a/managers/manager_test.go
+++ b/managers/manager_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestManagePackages(t *testing.T) {

--- a/managers/pacman.go
+++ b/managers/pacman.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"slices"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type pacman struct {

--- a/managers/yum.go
+++ b/managers/yum.go
@@ -10,7 +10,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type yum struct {

--- a/managers/zypper.go
+++ b/managers/zypper.go
@@ -3,7 +3,7 @@ package managers
 import (
 	"errors"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type zypper struct {

--- a/sources/almalinux-http.go
+++ b/sources/almalinux-http.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type almalinux struct {

--- a/sources/alpaquita-http.go
+++ b/sources/alpaquita-http.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type alpaquita struct {

--- a/sources/alpine-http.go
+++ b/sources/alpine-http.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type alpineLinux struct {

--- a/sources/alt-http.go
+++ b/sources/alt-http.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type altLinux struct {

--- a/sources/apertis-http.go
+++ b/sources/apertis-http.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type apertis struct {

--- a/sources/archlinux-http.go
+++ b/sources/archlinux-http.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/antchfx/htmlquery"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type archlinux struct {

--- a/sources/busybox.go
+++ b/sources/busybox.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type busybox struct {

--- a/sources/centos-http.go
+++ b/sources/centos-http.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type centOS struct {

--- a/sources/common.go
+++ b/sources/common.go
@@ -18,7 +18,7 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type common struct {

--- a/sources/common_test.go
+++ b/sources/common_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 func TestVerifyFile(t *testing.T) {

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -10,7 +10,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/shared/util"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type debootstrap struct {

--- a/sources/fedora-http.go
+++ b/sources/fedora-http.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/lxc/incus/v6/shared/subprocess"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type fedora struct {

--- a/sources/funtoo-http.go
+++ b/sources/funtoo-http.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type funtoo struct {

--- a/sources/gentoo.go
+++ b/sources/gentoo.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type gentoo struct {

--- a/sources/nixos-http.go
+++ b/sources/nixos-http.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type nixos struct {

--- a/sources/openeuler-http.go
+++ b/sources/openeuler-http.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type openEuler struct {

--- a/sources/opensuse-http.go
+++ b/sources/opensuse-http.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/antchfx/htmlquery"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type opensuse struct {

--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type openwrt struct {

--- a/sources/oraclelinux-http.go
+++ b/sources/oraclelinux-http.go
@@ -14,7 +14,7 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type oraclelinux struct {

--- a/sources/plamolinux-http.go
+++ b/sources/plamolinux-http.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/antchfx/htmlquery"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type plamolinux struct {

--- a/sources/rhel-common.go
+++ b/sources/rhel-common.go
@@ -11,7 +11,7 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type commonRHEL struct {

--- a/sources/rocky-http.go
+++ b/sources/rocky-http.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type rockylinux struct {

--- a/sources/rootfs-http.go
+++ b/sources/rootfs-http.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type rootfs struct {

--- a/sources/rpmbootstrap.go
+++ b/sources/rpmbootstrap.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type rpmbootstrap struct {

--- a/sources/slackware-http.go
+++ b/sources/slackware-http.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/antchfx/htmlquery"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type slackware struct {

--- a/sources/source.go
+++ b/sources/source.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 // ErrUnknownDownloader represents the unknown downloader error.

--- a/sources/springdalelinux-http.go
+++ b/sources/springdalelinux-http.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type springdalelinux struct {

--- a/sources/ubuntu-http.go
+++ b/sources/ubuntu-http.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type ubuntu struct {

--- a/sources/voidlinux-http.go
+++ b/sources/voidlinux-http.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type voidlinux struct {

--- a/sources/vyos-http.go
+++ b/sources/vyos-http.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-github/v56/github"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type vyos struct {

--- a/windows/repack_util.go
+++ b/windows/repack_util.go
@@ -13,7 +13,7 @@ import (
 	incus "github.com/lxc/incus/v6/shared/util"
 	"github.com/sirupsen/logrus"
 
-	"github.com/lxc/distrobuilder/shared"
+	"github.com/lxc/distrobuilder/v3/shared"
 )
 
 type RepackUtil struct {


### PR DESCRIPTION
We're now using semver for our tags which changes Go's import behavior.