### PR TITLE
github: build distrobuilder in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,3 +26,26 @@ jobs:
         with:
           name: documentation
           path: doc/html
+
+  binary:
+    name: Binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y \
+           	libbtrfs-dev \
+            libgpgme-dev \
+            squashfs-tools
+
+      - name: Build
+        run: go build ./...


### PR DESCRIPTION
There appears to be a gap in the CI, where the main binary is never built.

This build should fail due to the dependency issue reported in #977 