### PR TITLE
more openwrt enhancements

### DIFF
--- a/generators/incus-agent.go
+++ b/generators/incus-agent.go
@@ -237,8 +237,8 @@ required_dirs=/dev/virtio-ports/
 
 func (g *incusAgent) handleProcd() error {
 	incusAgentProcdScript := `#!/etc/rc.common
-START=96
-STOP=04
+START=05
+STOP=85
 USE_PROCD=1
 
 start_service() {
@@ -284,16 +284,16 @@ exec /run/incus_agent/incus-agent $@
 		return fmt.Errorf("Failed to write file %q: %w", initPath, err)
 	}
 
-	initPathS94 := filepath.Join(g.sourceDir, "/etc/rc.d/S94incus-agent")
-	err = os.Symlink("/etc/init.d/incus-agent", initPathS94)
+	initPathStart := filepath.Join(g.sourceDir, "/etc/rc.d/S05incus-agent")
+	err = os.Symlink("/etc/init.d/incus-agent", initPathStart)
 	if err != nil {
-		return fmt.Errorf("Failed to create symlink %q: %w", initPathS94, err)
+		return fmt.Errorf("Failed to create symlink %q: %w", initPathStart, err)
 	}
 
-	initPathK40 := filepath.Join(g.sourceDir, "/etc/rc.d/K04incus-agent")
-	err = os.Symlink("/etc/init.d/incus-agent", initPathK40)
+	initPathKill := filepath.Join(g.sourceDir, "/etc/rc.d/K85incus-agent")
+	err = os.Symlink("/etc/init.d/incus-agent", initPathKill)
 	if err != nil {
-		return fmt.Errorf("Failed to create symlink %q: %w", initPathK40, err)
+		return fmt.Errorf("Failed to create symlink %q: %w", initPathKill, err)
 	}
 
 	// not present by default on openwrt

--- a/sources/openwrt-http.go
+++ b/sources/openwrt-http.go
@@ -123,23 +123,29 @@ func (s *openwrt) unpackCombinedImg(imagePath, rootfsDir string) error {
 	// Image comes with an esp (vfat) and rootfs (ext4) partition
 	// We need the bootloader (grub) from the esp as it is not distributed otherwise
 	var out strings.Builder
-	err := shared.RunCommand(s.ctx, nil, &out, "fdisk", "-l", "-o", "Start,Sectors", imagePath)
+	err := shared.RunCommand(s.ctx, nil, &out,
+		"partx",
+		"--bytes", // report SIZE in bytes
+		"--pairs", // use easily parsable output format
+		"--output", "START,SIZE",
+		"--nr", "1:2", // we only care about the first two partitions
+		imagePath,
+	)
 	if err != nil {
-		return fmt.Errorf(`failed to run "fdisk": %w`, err)
+		return fmt.Errorf(`failed to run "partx": %w`, err)
 	}
 
 	// we expect the first match to be the esp, the second to be the rootfs
 	// openwrt also has a very small third partition (number 128) for some legacy stuff
-	// should match the first two rows from a table like this
 	//
-	// Start Sectors
-	//   512   32768
-	// 33280  212992
-	//    34     478
-	regex := regexp.MustCompile(`\n\s*(\d+)\s+(\d+)`)
+	// The above partx command gives output like this:
+	// START="512" SIZE="16777216"
+	// START="33280" SIZE="109051904"
+
+	regex := regexp.MustCompile(`START="(\d+)" SIZE="(\d+)"\n`)
 	matches := regex.FindAllStringSubmatch(out.String(), 2)
 	if len(matches) != 2 {
-		return fmt.Errorf(`Failed to parse output of "fdisk"; unexpected number of matches: %d`, len(matches))
+		return fmt.Errorf(`Failed to parse output of "partx"; unexpected number of matches: %d`, len(matches))
 	}
 
 	// a partition has an offset and size in bytes; we are looking for 2 partitions:
@@ -152,6 +158,10 @@ func (s *openwrt) unpackCombinedImg(imagePath, rootfsDir string) error {
 		partitions[i][0], err = strconv.Atoi(matches[i][1])
 		if err != nil {
 			return fmt.Errorf("Failed to parse partition offset: %w", err)
+		} else {
+			// openwrt uses a sector size of 512; could detect this, but not likely to change
+			// partx reports START in sectors, mount needs the numbers in bytes
+			partitions[i][0] *= 512
 		}
 
 		// size
@@ -159,11 +169,6 @@ func (s *openwrt) unpackCombinedImg(imagePath, rootfsDir string) error {
 		if err != nil {
 			return fmt.Errorf("Failed to parse partition size: %w", err)
 		}
-
-		// openwrt uses a sector size of 512; could detect this, but not likely to change
-		// fdisk reports in sectors, mount needs the numbers in bytes
-		partitions[i][0] *= 512
-		partitions[i][1] *= 512
 	}
 
 	espTmpDir, err := os.MkdirTemp(s.cacheDir, "temp_")


### PR DESCRIPTION
I have another pr coming in lxc-ci which fixes the hostname not being set properly. It makes use of templates which need to be present during early boot. For this to work, incus-agent needs to run early in the boot proces.

Also `fdisk` is kind of ugly to use w.r.t. output parsing, so use partx which is meant for this and installed by default on debain based distros.