### PR TITLE
FIX the outdated RPM-GPG-KEY of Oralce Linux.

### DIFF
--- a/sources/oraclelinux-http.go
+++ b/sources/oraclelinux-http.go
@@ -232,7 +232,7 @@ func (s *oraclelinux) unpackISO(latestUpdate, filePath, rootfsDir string) error 
 		array := [][]string{
 			{filepath.Join(tempRootDir, filepath.Base(rpmPkg)), fmt.Sprintf("%s/%s", baseURL, rpmPkg)},
 			{filepath.Join(tempRootDir, filepath.Base(yumPkg)), fmt.Sprintf("%s/%s", baseURL, yumPkg)},
-			{filepath.Join(tempRootDir, "RPM-GPG-KEY-oracle"), "https://oss.oracle.com/ol6/RPM-GPG-KEY-oracle"},
+			{filepath.Join(tempRootDir, "RPM-GPG-KEY-oracle"), "https://yum.oracle.com/RPM-GPG-KEY-oracle-ol10"},
 		}
 
 		for _, elem := range array {


### PR DESCRIPTION
The outdated RPM-GPG-KEY was causing a timestamp error during the build of Oracle Linux 10.