### PR TITLE
lxc.generator: Re-enable LoadCredential/ImportCredential

### DIFF
--- a/distrobuilder/lxc.generator
+++ b/distrobuilder/lxc.generator
@@ -94,9 +94,7 @@ fix_systemd_override_unit() {
 		[ "${SYSTEMD}" -ge 232 ] && echo "ProtectControlGroups=no";
 		[ "${SYSTEMD}" -ge 232 ] && echo "ProtectKernelTunables=no";
 		[ "${SYSTEMD}" -ge 239 ] && echo "NoNewPrivileges=no";
-		[ "${SYSTEMD}" -ge 249 ] && echo "LoadCredential=";
 		[ "${SYSTEMD}" -ge 254 ] && echo "PrivateNetwork=no";
-		[ "${SYSTEMD}" -ge 256 ] && echo "ImportCredential=";
 
 		# Additional settings for privileged containers
 		if is_lxc_privileged_container; then


### PR DESCRIPTION
In current Incus containers, those two appear to now work properly, so let's try to re-enable them and see if tests clear on all images.

Closes #985