### PR TITLE
incus: Add configurable VM boot partition size

### DIFF
--- a/distrobuilder/main_incus.go
+++ b/distrobuilder/main_incus.go
@@ -327,7 +327,7 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
 
 		imgFile := filepath.Join(c.global.flagCacheDir, imgFilename)
 
-		vm, err = newVM(c.global.ctx, imgFile, vmDir, c.global.definition.Targets.Incus.VM.Filesystem, c.global.definition.Targets.Incus.VM.Size)
+		vm, err = newVM(c.global.ctx, imgFile, vmDir, c.global.definition.Targets.Incus.VM.Filesystem, c.global.definition.Targets.Incus.VM.Size, c.global.definition.Targets.Incus.VM.BootSize)
 		if err != nil {
 			return fmt.Errorf("Failed to instantiate VM: %w", err)
 		}

--- a/distrobuilder/vm.go
+++ b/distrobuilder/vm.go
@@ -23,10 +23,11 @@ type vm struct {
 	rootfsDir  string
 	bootfsDir  string
 	size       uint64
+	bootSize   uint64
 	ctx        context.Context
 }
 
-func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64) (*vm, error) {
+func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64, bootSize uint64) (*vm, error) {
 	if fs == "" {
 		fs = "ext4"
 	}
@@ -39,7 +40,11 @@ func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64) (*
 		size = 4294967296
 	}
 
-	return &vm{ctx: ctx, imageFile: imageFile, rootfsDir: rootfsDir, rootFS: fs, size: size}, nil
+	if bootSize == 0 {
+		bootSize = 104857600
+	}
+
+	return &vm{ctx: ctx, imageFile: imageFile, rootfsDir: rootfsDir, rootFS: fs, size: size, bootSize: bootSize}, nil
 }
 
 func (v *vm) getLoopDev() string {
@@ -121,9 +126,10 @@ func (v *vm) createEmptyDiskImage() error {
 
 func (v *vm) createPartitions(args ...[]string) error {
 	if len(args) == 0 {
+		bootSizeK := v.bootSize / 1024
 		args = [][]string{
 			{"--zap-all"},
-			{"--new=1::+100M", "-t 1:EF00"},
+			{fmt.Sprintf("--new=1::+%dK", bootSizeK), "-t 1:EF00"},
 			{"--new=2::", "-t 2:8300"},
 		}
 	}

--- a/distrobuilder/vm_test.go
+++ b/distrobuilder/vm_test.go
@@ -23,6 +23,7 @@ func lsblkOutputHelper(t *testing.T, v *vm, args [][]string) func() {
 
 	v.imageFile = f.Name()
 	v.size = 2e8
+	v.bootSize = 1e8
 	defer func() {
 		if err != nil {
 			os.RemoveAll(v.imageFile)

--- a/doc/examples/scheme.yaml
+++ b/doc/examples/scheme.yaml
@@ -59,6 +59,7 @@ targets:
   incus:
     vm:
       size: 2147483648
+      boot_size: 268435456
       filesystem: ext4
 
 files:

--- a/shared/definition.go
+++ b/shared/definition.go
@@ -187,6 +187,7 @@ type DefinitionTargetLXC struct {
 // DefinitionTargetIncusVM represents Incus VM specific options.
 type DefinitionTargetIncusVM struct {
 	Size       uint64 `yaml:"size,omitempty"`
+	BootSize   uint64 `yaml:"boot_size,omitempty"`
 	Filesystem string `yaml:"filesystem,omitempty"`
 }
 


### PR DESCRIPTION
Adds a boot_size option to the Incus VM target to configure the size of the EFI system partition.

The size is specified in bytes and defaults to 100 MiB when unset.

Fixes #1008